### PR TITLE
Update to fix device placement in LinearLeastSquares

### DIFF
--- a/sigpy/app.py
+++ b/sigpy/app.py
@@ -177,7 +177,7 @@ class LinearLeastSquares(App):
             with self.y_device:
                 self.x = self.y_device.xp.zeros(A.ishape, dtype=y.dtype)
 
-        self.x_device = backend.get_device(x)
+        self.x_device = backend.get_device(self.x)
         self._get_alg()
         if self.save_objective_values:
             self.objective_values = []


### PR DESCRIPTION
In linear least squares if x is initialized x_device does not get updated correctly. 
