### PR TITLE
Pytorch interop

### DIFF
--- a/sigpy/__init__.py
+++ b/sigpy/__init__.py
@@ -19,12 +19,14 @@ is the LinearLeastSquares App.
 """
 from sigpy import alg, app, config, linop, prox
 
-from sigpy import backend, block, conv, interp, fourier, sim, thresh, util
+from sigpy import (backend, block, conv, interp,
+                   fourier, pytorch, sim, thresh, util)
 from sigpy.backend import *  # noqa
 from sigpy.block import *  # noqa
 from sigpy.conv import *  # noqa
 from sigpy.interp import *  # noqa
 from sigpy.fourier import *  # noqa
+from sigpy.pytorch import * # noqa
 from sigpy.sim import *  # noqa
 from sigpy.thresh import *  # noqa
 from sigpy.util import *  # noqa
@@ -35,6 +37,7 @@ __all__.extend(block.__all__)
 __all__.extend(conv.__all__)
 __all__.extend(interp.__all__)
 __all__.extend(fourier.__all__)
+__all__.extend(pytorch.__all__)
 __all__.extend(sim.__all__)
 __all__.extend(thresh.__all__)
 __all__.extend(util.__all__)

--- a/sigpy/config.py
+++ b/sigpy/config.py
@@ -15,3 +15,5 @@ else:
     nccl_enabled = False
 
 mpi4py_enabled = util.find_spec("mpi4py") is not None
+
+pytorch_enabled = util.find_spec("torch") is not None

--- a/sigpy/plot.py
+++ b/sigpy/plot.py
@@ -18,7 +18,6 @@ import uuid
 import subprocess
 import datetime
 import numpy as np
-import matplotlib.pyplot as plt
 import sigpy as sp
 
 
@@ -75,7 +74,7 @@ class ImagePlot(object):
             raise TypeError(
                 'Image dimension must at least be two, got {im_ndim}'.format(
                     im_ndim=im.ndim))
-
+        import matplotlib.pyplot as plt
         self.axim = None
         self.im = im
         self.fig = plt.figure()
@@ -559,6 +558,8 @@ class LinePlot(object):
 
     def __init__(self, arr, x=-1, hide=False, mode='m', title='',
                  save_basename='Figure', fps=10):
+        import matplotlib.pyplot as plt
+
         self.arr = arr
         self.axarr = None
 
@@ -833,6 +834,7 @@ class ScatterPlot(object):
             title='',
             save_basename='Figure',
             fps=10):
+        import matplotlib.pyplot as plt
 
         self.coord = coord
         assert coord.shape[-1] == 2

--- a/sigpy/pytorch.py
+++ b/sigpy/pytorch.py
@@ -9,7 +9,7 @@ __all__ = []
 if config.pytorch_enabled:
     __all__ += ['to_pytorch', 'from_pytorch']
 
-    def to_pytorch(array):
+    def to_pytorch(array, requires_grad=True):
         """Zero-copy conversion from numpy/cupy array to pytorch tensor.
 
         For complex array input, returns a tensor with shape + [2],
@@ -34,9 +34,12 @@ if config.pytorch_enabled:
                 array = array.reshape(shape + (2, ))
 
         if device == backend.cpu_device:
-            return torch.from_numpy(array)
+            tensor = torch.from_numpy(array)
         else:
-            return from_dlpack(array.toDlpack())
+            tensor = from_dlpack(array.toDlpack())
+
+        tensor.requires_grad = requires_grad
+        return tensor
 
     def from_pytorch(tensor, iscomplex=False):
         """Zero-copy conversion from pytorch tensor to numpy/cupy array.
@@ -56,7 +59,7 @@ if config.pytorch_enabled:
 
         device = tensor.device
         if device.type == 'cpu':
-            output = tensor.numpy()
+            output = tensor.detach().numpy()
         else:
             if config.cupy_enabled:
                 import cupy as cp

--- a/sigpy/pytorch.py
+++ b/sigpy/pytorch.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""This module provides functions for interoperability
+between sigpy and pytorch.
+"""
+import numpy as np
+from sigpy import backend, config
+
+__all__ = []
+if config.pytorch_enabled:
+    __all__ += ['to_pytorch', 'from_pytorch']
+
+    def to_pytorch(array):
+        """Zero-copy conversion from numpy/cupy array to pytorch tensor.
+
+        For complex array input, returns a tensor with shape + [2],
+        where tensor[..., 0] and tensor[..., 1] represent the real
+        and imaginary.
+
+        Args:
+            array (numpy/cupy array): input.
+
+        Returns:
+            PyTorch tensor.
+
+        """
+        import torch
+        from torch.utils.dlpack import from_dlpack
+
+        device = backend.get_device(array)
+        if not np.issubdtype(array.dtype, np.floating):
+            with device:
+                shape = array.shape
+                array = array.view(dtype=array.real.dtype)
+                array = array.reshape(shape + (2, ))
+
+        if device == backend.cpu_device:
+            return torch.from_numpy(array)
+        else:
+            return from_dlpack(array.toDlpack())
+
+    def from_pytorch(tensor, iscomplex=False):
+        """Zero-copy conversion from pytorch tensor to numpy/cupy array.
+
+        If iscomplex, then tensor must have the last dimension as 2,
+        and the output will be viewed as a complex valued array.
+
+        Args:
+            tensor (PyTorch tensor): input.
+            iscomplex (bool): whether input represents complex valued tensor.
+
+        Returns:
+            Numpy/cupy array.
+
+        """
+        from torch.utils.dlpack import to_dlpack
+
+        device = tensor.device
+        if device.type == 'cpu':
+            output = tensor.numpy()
+        else:
+            if config.cupy_enabled:
+                import cupy as cp
+                output = cp.fromDlpack(to_dlpack(tensor))
+            else:
+                raise TypeError('CuPy not installed, '
+                                'but trying to convert GPU PyTorch Tensor.')
+
+        if iscomplex:
+            if output.shape[-1] != 2:
+                raise ValueError('shape[-1] must be 2 when iscomplex is '
+                                 'specified, but got {}'.format(output.shape))
+
+            with backend.get_device(output):
+                if output.dtype == np.float32:
+                    output = output.view(np.complex64)
+                elif output.dtype == np.float64:
+                    output = output.view(np.complex128)
+
+        return output

--- a/sigpy/pytorch.py
+++ b/sigpy/pytorch.py
@@ -79,6 +79,8 @@ if config.pytorch_enabled:
                 elif output.dtype == np.float64:
                     output = output.view(np.complex128)
 
+                output = output.reshape(output.shape[:-1])
+
         return output
 
     def to_pytorch_function(linop,

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -1,0 +1,68 @@
+import unittest
+import numpy as np
+from sigpy import backend, config, pytorch
+
+
+if config.pytorch_enabled:
+    import torch
+
+    if __name__ == '__main__':
+        unittest.main()
+
+    devices = [backend.cpu_device]
+    if config.cupy_enabled:
+        devices.append(backend.Device(0))
+
+    class TestPytorch(unittest.TestCase):
+
+        def test_to_torch(self):
+            for dtype in [np.float32, np.float64]:
+                for device in devices:
+                    with self.subTest(device=device, dtype=dtype):
+                        xp = device.xp
+                        array = xp.array([1, 2, 3], dtype=dtype)
+                        tensor = pytorch.to_pytorch(array)
+                        tensor[0] = 0
+                        xp.testing.assert_allclose(array, [0, 2, 3])
+
+        def test_to_torch_complex(self):
+            for dtype in [np.complex64, np.complex128]:
+                for device in devices:
+                    with self.subTest(device=device, dtype=dtype):
+                        xp = device.xp
+                        array = xp.array([1 + 1j, 2 + 2j, 3 + 3j], dtype=dtype)
+                        tensor = pytorch.to_pytorch(array)
+                        tensor[0, 0] = 0
+                        xp.testing.assert_allclose(array, [1j, 2 + 2j, 3 + 3j])
+
+        def test_from_torch(self):
+            for dtype in [torch.float32, torch.float64]:
+                for device in devices:
+                    with self.subTest(device=device, dtype=dtype):
+                        if device == backend.cpu_device:
+                            torch_device = torch.device('cpu')
+                        else:
+                            torch_device = torch.device('cuda:0')
+
+                        tensor = torch.tensor([1, 2, 3],
+                                              dtype=dtype, device=torch_device)
+                        array = pytorch.from_pytorch(tensor)
+                        array[0] = 0
+                        np.testing.assert_allclose(tensor.cpu().numpy(),
+                                                   [0, 2, 3])
+
+        def test_from_torch_complex(self):
+            for dtype in [torch.float32, torch.float64]:
+                for device in devices:
+                    with self.subTest(device=device, dtype=dtype):
+                        if device == backend.cpu_device:
+                            torch_device = torch.device('cpu')
+                        else:
+                            torch_device = torch.device('cuda:0')
+
+                        tensor = torch.tensor([[1, 1], [2, 2], [3, 3]],
+                                              dtype=dtype, device=torch_device)
+                        array = pytorch.from_pytorch(tensor, iscomplex=True)
+                        array[0] -= 1
+                        np.testing.assert_allclose(tensor.cpu().numpy(),
+                                                   [[0, 1], [2, 2], [3, 3]])


### PR DESCRIPTION
- Add functions to perform zero-copy conversion between between numpy/cupy arrays and Pytorch tensor.
- Add a function to convert SigPy Linop to a PyTorch function.

For complex arrays with shape `s`, the corresponding output PyTorch tensor has shape `s + [2]`, where the first channel represents real, and the second channel represents imaginary.

The converted PyTorch function behaves like a native PyTorch function with zero additional copying. It can be back propagated, and applied on GPU tensors.