### PR TITLE
Strided convolution

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ The conversion has no copying, and the resulting Tensor and Function can be back
 Installation
 ------------
 
-SigPy requires Python version >= 3.5. The core module depends on ``numba``, ``numpy``, ``PyWavelets``, and ``tqdm``.
+SigPy requires Python version >= 3.5. The core module depends on ``numba``, ``numpy``, ``PyWavelets``, ``scipy``, and ``tqdm``.
 
 Additional features can be unlocked by installing the appropriate packages. To enable the plotting functions, you will need to install ``matplotlib``. To enable CUDA support, you will need to install ``cupy``. And to enable MPI support, you will need to install ``mpi4py``.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numba
 numpy
 PyWavelets
 tqdm
+scipy

--- a/sigpy/conv.py
+++ b/sigpy/conv.py
@@ -45,7 +45,7 @@ def convolve(data, filt,
     if device == backend.cpu_device:
         output = _convolve(data, filt, mode=mode, strides=strides,
                            multi_channel=multi_channel)
-    else:
+    else:  # pragma: no cover
         if config.cudnn_enabled:
             if np.issubdtype(data.dtype, np.floating):
                 output = _convolve_cuda(data, filt,
@@ -100,7 +100,7 @@ def convolve_adjoint_data(output, filt, data_shape,
         data = _convolve_adjoint_data(output, filt, data_shape,
                                       mode=mode, strides=strides,
                                       multi_channel=multi_channel)
-    else:
+    else:  # pragma: no cover
         if config.cudnn_enabled:
             if np.issubdtype(output.dtype, np.floating):
                 data = _convolve_adjoint_data_cuda(
@@ -155,7 +155,7 @@ def convolve_adjoint_filter(output, data, filt_shape,
         filt = _convolve_adjoint_filter(output, data, filt_shape,
                                         mode=mode, strides=strides,
                                         multi_channel=multi_channel)
-    else:
+    else:  # pragma: no cover
         if config.cudnn_enabled:
             if np.issubdtype(output.dtype, np.floating):
                 filt = _convolve_adjoint_filter_cuda(

--- a/sigpy/linop.py
+++ b/sigpy/linop.py
@@ -1442,7 +1442,7 @@ class ConvolveData(Linop):
     def _adjoint_linop(self):
         return ConvolveAdjointData(
             self.ishape, self.filt,
-            mode=self.mode,
+            mode=self.mode, strides=self.strides,
             multi_channel=self.multi_channel)
 
 

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -7,6 +7,9 @@ from sigpy import backend, conv, util, config
 if __name__ == '__main__':
     unittest.main()
 
+dtypes = [np.float32, np.float64,
+          np.complex64, np.complex128]
+
 
 class TestConv(unittest.TestCase):
 
@@ -16,111 +19,97 @@ class TestConv(unittest.TestCase):
         if config.cupy_enabled:
             devices.append(backend.Device(0))
 
-        dtypes = [np.float32, np.float64,
-                  np.complex64, np.complex128]
         for device in devices:
             xp = device.xp
             with device:
                 for dtype in dtypes:
                     with self.subTest(dtype=dtype, device=device):
-                        x = util.dirac([1, 3], device=device, dtype=dtype)
-                        W = xp.ones([1, 3], dtype=dtype)
-                        y = backend.to_device(conv.convolve(
-                            x, W, mode=mode))
-                        npt.assert_allclose(y, [[1]], atol=1e-5)
+                        data = util.dirac([1, 3], device=device, dtype=dtype)
+                        filt = xp.ones([1, 3], dtype=dtype)
+                        output = backend.to_device(conv.convolve(
+                            data, filt, mode=mode))
+                        npt.assert_allclose(output, [[1]], atol=1e-5)
 
-                        x = util.dirac([1, 3], device=device, dtype=dtype)
-                        W = xp.ones([1, 2], dtype=dtype)
-                        y = backend.to_device(conv.convolve(
-                            x, W, mode=mode))
-                        npt.assert_allclose(y, [[1, 1]], atol=1e-5)
+                        data = util.dirac([1, 3], device=device, dtype=dtype)
+                        filt = xp.ones([1, 2], dtype=dtype)
+                        output = backend.to_device(conv.convolve(
+                            data, filt, mode=mode))
+                        npt.assert_allclose(output, [[1, 1]], atol=1e-5)
 
-                        x = util.dirac([1, 3], device=device, dtype=dtype)
-                        W = xp.ones([2, 1, 3], dtype=dtype)
-                        y = backend.to_device(
-                            conv.convolve(
-                                x,
-                                W,
-                                mode=mode,
-                                output_multi_channel=True),
+                        data = util.dirac([1, 1, 3], device=device,
+                                          dtype=dtype)
+                        filt = xp.ones([2, 1, 1, 3], dtype=dtype)
+                        output = backend.to_device(
+                            conv.convolve(data, filt,
+                                          mode=mode,
+                                          multi_channel=True),
                             backend.cpu_device)
-                        npt.assert_allclose(y, [[[1]],
-                                                [[1]]], atol=1e-5)
+                        npt.assert_allclose(output, [[[1]],
+                                                     [[1]]], atol=1e-5)
+
+                        data = util.dirac([1, 1, 3], device=device,
+                                          dtype=dtype)
+                        filt = xp.ones([2, 1, 1, 3], dtype=dtype)
+                        strides = [1, 2]
+                        output = backend.to_device(
+                            conv.convolve(data, filt,
+                                          mode=mode, strides=strides,
+                                          multi_channel=True),
+                            backend.cpu_device)
+                        npt.assert_allclose(output, [[[1]],
+                                                     [[1]]], atol=1e-5)
 
     def test_convolve_full(self):
         mode = 'full'
         devices = [backend.cpu_device]
         if config.cupy_enabled:
             devices.append(backend.Device(0))
+            dtypes = [np.float32, np.float64,
+                      np.complex64, np.complex128]
 
         for device in devices:
             xp = device.xp
             with device:
-                for dtype in [np.float32, np.float64,
-                              np.complex64, np.complex128]:
+                for dtype in dtypes:
                     with self.subTest(dtype=dtype, device=device):
-                        x = util.dirac([1, 3], device=device, dtype=dtype)
-                        W = xp.ones([1, 3], dtype=dtype)
-                        y = backend.to_device(conv.convolve(
-                            x, W, mode=mode))
-                        npt.assert_allclose(y, [[0, 1, 1, 1, 0]], atol=1e-5)
+                        data = util.dirac([1, 3], device=device, dtype=dtype)
+                        filt = xp.ones([1, 3], dtype=dtype)
+                        output = backend.to_device(conv.convolve(
+                            data, filt, mode=mode))
+                        npt.assert_allclose(output, [[0, 1, 1, 1, 0]],
+                                            atol=1e-5)
 
-                        x = util.dirac([1, 3], device=device, dtype=dtype)
-                        W = xp.ones([1, 2], dtype=dtype)
-                        y = backend.to_device(conv.convolve(
-                            x, W, mode=mode))
-                        npt.assert_allclose(y, [[0, 1, 1, 0]], atol=1e-5)
+                        data = util.dirac([1, 3], device=device, dtype=dtype)
+                        filt = xp.ones([1, 2], dtype=dtype)
+                        output = backend.to_device(conv.convolve(
+                            data, filt, mode=mode))
+                        npt.assert_allclose(output, [[0, 1, 1, 0]], atol=1e-5)
 
-                        x = util.dirac([1, 3], device=device, dtype=dtype)
-                        W = xp.ones([2, 1, 3], dtype=dtype)
-                        y = backend.to_device(
-                            conv.convolve(
-                                x,
-                                W,
-                                mode=mode,
-                                output_multi_channel=True),
+                        data = util.dirac([1, 1, 3], device=device,
+                                          dtype=dtype)
+                        filt = xp.ones([2, 1, 1, 3], dtype=dtype)
+                        output = backend.to_device(
+                            conv.convolve(data, filt,
+                                          mode=mode,
+                                          multi_channel=True),
                             backend.cpu_device)
-                        npt.assert_allclose(y, [[[0, 1, 1, 1, 0]],
-                                                [[0, 1, 1, 1, 0]]], atol=1e-5)
+                        npt.assert_allclose(output, [[[0, 1, 1, 1, 0]],
+                                                     [[0, 1, 1, 1, 0]]],
+                                            atol=1e-5)
 
-    def test_convolve_strides(self):
-        mode = 'full'
-        devices = [backend.cpu_device]
-        if config.cupy_enabled:
-            devices.append(backend.Device(0))
+                        data = util.dirac([1, 1, 3], device=device,
+                                          dtype=dtype)
+                        filt = xp.ones([2, 1, 1, 3], dtype=dtype)
+                        strides = [1, 2]
+                        output = backend.to_device(
+                            conv.convolve(data, filt,
+                                          mode=mode,
+                                          strides=strides,
+                                          multi_channel=True))
+                        npt.assert_allclose(output, [[[0, 1, 0]],
+                                                     [[0, 1, 0]]], atol=1e-5)
 
-        strides = (1, 2)
-        for device in devices:
-            for dtype in [np.float32, np.float64,
-                          np.complex64, np.complex128]:
-                with self.subTest(device=device, dtype=dtype):
-                    xp = device.xp
-                    with device:
-                        x = util.dirac([1, 3], device=device, dtype=dtype)
-                        W = xp.ones([1, 3], dtype=dtype)
-                        y = backend.to_device(conv.convolve(
-                            x, W, mode=mode, strides=strides))
-                        npt.assert_allclose(y, [[0, 1, 0]], atol=1e-5)
-
-                        x = util.dirac([1, 3], device=device, dtype=dtype)
-                        W = xp.ones([1, 2], dtype=dtype)
-                        y = backend.to_device(conv.convolve(
-                            x, W, mode=mode, strides=strides))
-                        npt.assert_allclose(y, [[0, 1]], atol=1e-5)
-
-                        x = util.dirac([1, 3], device=device, dtype=dtype)
-                        W = xp.ones([2, 1, 3], dtype=dtype)
-                        y = backend.to_device(
-                            conv.convolve(
-                                x,
-                                W,
-                                mode=mode,
-                                strides=strides,
-                                output_multi_channel=True))
-                        npt.assert_allclose(y, [[[0, 1, 0]],
-                                                [[0, 1, 0]]], atol=1e-5)
-
-    def test_convolve_adjoint_input_valid(self):
+    def test_convolve_adjoint_data_valid(self):
         mode = 'valid'
         devices = [backend.cpu_device]
         if config.cupy_enabled:
@@ -129,33 +118,46 @@ class TestConv(unittest.TestCase):
         for device in devices:
             xp = device.xp
             with device:
-                for dtype in [np.float32, np.float64,
-                              np.complex64, np.complex128]:
+                for dtype in dtypes:
                     with self.subTest(dtype=dtype, device=device):
-                        y = xp.ones([1, 1], dtype=dtype)
-                        W = xp.ones([1, 3], dtype=dtype)
-                        x = backend.to_device(conv.convolve_adjoint_input(
-                            W, y, mode=mode))
-                        npt.assert_allclose(x, [[1, 1, 1]], atol=1e-5)
+                        output = xp.ones([1, 1], dtype=dtype)
+                        filt = xp.ones([1, 3], dtype=dtype)
+                        data_shape = [1, 3]
+                        data = backend.to_device(conv.convolve_adjoint_data(
+                            output, filt, data_shape, mode=mode))
+                        npt.assert_allclose(data, [[1, 1, 1]], atol=1e-5)
 
-                        y = xp.ones([1, 2], dtype=dtype)
-                        W = xp.ones([1, 2], dtype=dtype)
-                        x = backend.to_device(conv.convolve_adjoint_input(
-                            W, y, mode=mode))
-                        npt.assert_allclose(x, [[1, 2, 1]], atol=1e-5)
+                        output = xp.ones([1, 2], dtype=dtype)
+                        filt = xp.ones([1, 2], dtype=dtype)
+                        data_shape = [1, 3]
+                        data = backend.to_device(conv.convolve_adjoint_data(
+                            output, filt, data_shape, mode=mode))
+                        npt.assert_allclose(data, [[1, 2, 1]], atol=1e-5)
 
-                        y = xp.ones([2, 1, 1], dtype=dtype)
-                        W = xp.ones([2, 1, 3], dtype=dtype)
-                        x = backend.to_device(
-                            conv.convolve_adjoint_input(
-                                W,
-                                y,
+                        output = xp.ones([2, 1, 1], dtype=dtype)
+                        filt = xp.ones([2, 1, 1, 3], dtype=dtype)
+                        data_shape = [1, 1, 3]
+                        data = backend.to_device(
+                            conv.convolve_adjoint_data(
+                                output, filt, data_shape,
                                 mode=mode,
-                                output_multi_channel=True),
+                                multi_channel=True),
                             backend.cpu_device)
-                        npt.assert_allclose(x, [[2, 2, 2]], atol=1e-5)
+                        npt.assert_allclose(data, [[[2, 2, 2]]], atol=1e-5)
 
-    def test_convolve_adjoint_input_full(self):
+                        output = xp.ones([2, 1, 1], dtype=dtype)
+                        filt = xp.ones([2, 1, 1, 3], dtype=dtype)
+                        data_shape = [1, 1, 4]
+                        strides = [1, 2]
+                        data = backend.to_device(
+                            conv.convolve_adjoint_data(
+                                output, filt, data_shape,
+                                mode=mode, strides=strides,
+                                multi_channel=True),
+                            backend.cpu_device)
+                        npt.assert_allclose(data, [[[2, 2, 2, 0]]], atol=1e-5)
+
+    def test_convolve_adjoint_data_full(self):
         mode = 'full'
         devices = [backend.cpu_device]
         if config.cupy_enabled:
@@ -164,32 +166,46 @@ class TestConv(unittest.TestCase):
         for device in devices:
             xp = device.xp
             with device:
-                for dtype in [np.float32, np.float64,
-                              np.complex64, np.complex128]:
+                for dtype in dtypes:
                     with self.subTest(dtype=dtype, device=device):
-                        y = xp.ones([1, 5], dtype=dtype)
-                        W = xp.ones([1, 3], dtype=dtype)
-                        x = backend.to_device(conv.convolve_adjoint_input(
-                            W, y, mode=mode))
-                        npt.assert_allclose(x, [[3, 3, 3]], atol=1e-5)
+                        output = xp.ones([1, 5], dtype=dtype)
+                        filt = xp.ones([1, 3], dtype=dtype)
+                        data_shape = [1, 3]
+                        data = backend.to_device(conv.convolve_adjoint_data(
+                            output, filt, data_shape, mode=mode))
+                        npt.assert_allclose(data, [[3, 3, 3]], atol=1e-5)
 
-                        y = xp.ones([1, 4], dtype=dtype)
-                        W = xp.ones([1, 2], dtype=dtype)
-                        x = backend.to_device(
-                            conv.convolve_adjoint_input(
-                                W, y, mode=mode))
-                        npt.assert_allclose(x, [[2, 2, 2]], atol=1e-5)
+                        output = xp.ones([1, 4], dtype=dtype)
+                        filt = xp.ones([1, 2], dtype=dtype)
+                        data_shape = [1, 3]
+                        data = backend.to_device(
+                            conv.convolve_adjoint_data(
+                                output, filt, data_shape, mode=mode))
+                        npt.assert_allclose(data, [[2, 2, 2]], atol=1e-5)
 
-                        y = xp.ones([2, 1, 5], dtype=dtype)
-                        W = xp.ones([2, 1, 3], dtype=dtype)
-                        x = backend.to_device(
-                            conv.convolve_adjoint_input(
-                                W,
-                                y,
+                        output = xp.ones([2, 1, 5], dtype=dtype)
+                        filt = xp.ones([2, 1, 1, 3], dtype=dtype)
+                        data_shape = [1, 1, 3]
+                        data = backend.to_device(
+                            conv.convolve_adjoint_data(
+                                output, filt, data_shape,
                                 mode=mode,
-                                output_multi_channel=True),
+                                multi_channel=True),
                             backend.cpu_device)
-                        npt.assert_allclose(x, [[6, 6, 6]], atol=1e-5)
+                        npt.assert_allclose(data, [[[6, 6, 6]]], atol=1e-5)
+
+                        output = xp.ones([2, 1, 5], dtype=dtype)
+                        filt = xp.ones([2, 1, 1, 3], dtype=dtype)
+                        data_shape = [1, 1, 8]
+                        strides = [1, 2]
+                        data = backend.to_device(
+                            conv.convolve_adjoint_data(
+                                output, filt, data_shape,
+                                mode=mode, strides=strides,
+                                multi_channel=True),
+                            backend.cpu_device)
+                        npt.assert_allclose(data, [[[4, 2, 4, 2, 4, 2, 4, 2]]],
+                                            atol=1e-5)
 
     def test_convolve_adjoint_filter_valid(self):
         mode = 'valid'
@@ -197,39 +213,51 @@ class TestConv(unittest.TestCase):
         if config.cupy_enabled:
             devices.append(backend.Device(0))
 
-        ndim = 2
         for device in devices:
             xp = device.xp
             with device:
-                for dtype in [np.float32, np.float64,
-                              np.complex64, np.complex128]:
+                for dtype in dtypes:
                     with self.subTest(dtype=dtype, device=device):
-                        x = xp.ones([1, 3], dtype=dtype)
-                        y = xp.ones([1, 1], dtype=dtype)
-                        W = backend.to_device(
+                        data = xp.ones([1, 3], dtype=dtype)
+                        output = xp.ones([1, 1], dtype=dtype)
+                        filt_shape = [1, 3]
+                        filt = backend.to_device(
                             conv.convolve_adjoint_filter(
-                                x, y, ndim, mode=mode))
-                        npt.assert_allclose(W, [[1, 1, 1]], atol=1e-5)
+                                output, data, filt_shape, mode=mode))
+                        npt.assert_allclose(filt, [[1, 1, 1]], atol=1e-5)
 
-                        x = xp.ones([1, 3], dtype=dtype)
-                        y = xp.ones([1, 2], dtype=dtype)
-                        W = backend.to_device(
+                        data = xp.ones([1, 3], dtype=dtype)
+                        output = xp.ones([1, 2], dtype=dtype)
+                        filt_shape = [1, 2]
+                        filt = backend.to_device(
                             conv.convolve_adjoint_filter(
-                                x, y, ndim, mode=mode))
-                        npt.assert_allclose(W, [[2, 2]], atol=1e-5)
+                                output, data, filt_shape, mode=mode))
+                        npt.assert_allclose(filt, [[2, 2]], atol=1e-5)
 
-                        x = xp.ones([1, 1, 3], dtype=dtype)
-                        y = xp.ones([2, 1, 1], dtype=dtype)
-                        W = backend.to_device(
+                        data = xp.ones([1, 1, 3], dtype=dtype)
+                        output = xp.ones([2, 1, 1], dtype=dtype)
+                        filt_shape = [2, 1, 1, 3]
+                        filt = backend.to_device(
                             conv.convolve_adjoint_filter(
-                                x,
-                                y,
-                                ndim,
+                                output, data, filt_shape,
                                 mode=mode,
-                                output_multi_channel=True),
+                                multi_channel=True),
                             backend.cpu_device)
-                        npt.assert_allclose(W, [[[1, 1, 1]],
-                                                [[1, 1, 1]]], atol=1e-5)
+                        npt.assert_allclose(filt, [[[[1, 1, 1]]],
+                                                   [[[1, 1, 1]]]], atol=1e-5)
+
+                        data = xp.ones([1, 1, 4], dtype=dtype)
+                        output = xp.ones([2, 1, 1], dtype=dtype)
+                        filt_shape = [2, 1, 1, 3]
+                        strides = [1, 2]
+                        filt = backend.to_device(
+                            conv.convolve_adjoint_filter(
+                                output, data, filt_shape,
+                                mode=mode, strides=strides,
+                                multi_channel=True),
+                            backend.cpu_device)
+                        npt.assert_allclose(filt, [[[[1, 1, 1]]],
+                                                   [[[1, 1, 1]]]], atol=1e-5)
 
     def test_convolve_adjoint_filter_full(self):
         mode = 'full'
@@ -237,36 +265,48 @@ class TestConv(unittest.TestCase):
         if config.cupy_enabled:
             devices.append(backend.Device(0))
 
-        ndim = 2
         for device in devices:
             xp = device.xp
             with device:
-                for dtype in [np.float32, np.float64,
-                              np.complex64, np.complex128]:
+                for dtype in dtypes:
                     with self.subTest(dtype=dtype, device=device):
-                        x = xp.ones([1, 3], dtype=dtype)
-                        y = xp.ones([1, 5], dtype=dtype)
-                        W = backend.to_device(
+                        data = xp.ones([1, 3], dtype=dtype)
+                        output = xp.ones([1, 5], dtype=dtype)
+                        filt_shape = [1, 3]
+                        filt = backend.to_device(
                             conv.convolve_adjoint_filter(
-                                x, y, ndim, mode=mode))
-                        npt.assert_allclose(W, [[3, 3, 3]], atol=1e-5)
+                                output, data, filt_shape, mode=mode))
+                        npt.assert_allclose(filt, [[3, 3, 3]], atol=1e-5)
 
-                        x = xp.ones([1, 3], dtype=dtype)
-                        y = xp.ones([1, 4], dtype=dtype)
-                        W = backend.to_device(
+                        data = xp.ones([1, 3], dtype=dtype)
+                        output = xp.ones([1, 4], dtype=dtype)
+                        filt_shape = [1, 2]
+                        filt = backend.to_device(
                             conv.convolve_adjoint_filter(
-                                x, y, ndim, mode=mode))
-                        npt.assert_allclose(W, [[3, 3]], atol=1e-5)
+                                output, data, filt_shape, mode=mode))
+                        npt.assert_allclose(filt, [[3, 3]], atol=1e-5)
 
-                        x = xp.ones([1, 1, 3], dtype=dtype)
-                        y = xp.ones([2, 1, 5], dtype=dtype)
-                        W = backend.to_device(
+                        data = xp.ones([1, 1, 3], dtype=dtype)
+                        output = xp.ones([2, 1, 5], dtype=dtype)
+                        filt_shape = [2, 1, 1, 3]
+                        filt = backend.to_device(
                             conv.convolve_adjoint_filter(
-                                x,
-                                y,
-                                ndim,
+                                output, data, filt_shape,
                                 mode=mode,
-                                output_multi_channel=True),
+                                multi_channel=True),
                             backend.cpu_device)
-                        npt.assert_allclose(W, [[[3, 3, 3]],
-                                                [[3, 3, 3]]], atol=1e-5)
+                        npt.assert_allclose(filt, [[[[3, 3, 3]]],
+                                                   [[[3, 3, 3]]]], atol=1e-5)
+
+                        data = xp.ones([1, 1, 3], dtype=dtype)
+                        output = xp.ones([2, 1, 3], dtype=dtype)
+                        filt_shape = [2, 1, 1, 3]
+                        strides = [1, 2]
+                        filt = backend.to_device(
+                            conv.convolve_adjoint_filter(
+                                output, data, filt_shape,
+                                mode=mode, strides=strides,
+                                multi_channel=True),
+                            backend.cpu_device)
+                        npt.assert_allclose(filt, [[[[2, 1, 2]]],
+                                                   [[[2, 1, 2]]]], atol=1e-5)

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -16,34 +16,36 @@ class TestConv(unittest.TestCase):
         if config.cupy_enabled:
             devices.append(backend.Device(0))
 
+        dtypes = [np.float32, np.float64,
+                  np.complex64, np.complex128]
         for device in devices:
             xp = device.xp
             with device:
-                for dtype in [np.float32, np.float64,
-                              np.complex64, np.complex128]:
-                    x = util.dirac([1, 3], device=device, dtype=dtype)
-                    W = xp.ones([1, 3], dtype=dtype)
-                    y = backend.to_device(conv.convolve(
-                        x, W, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(y, [[1]], atol=1e-5)
+                for dtype in dtypes:
+                    with self.subTest(dtype=dtype, device=device):
+                        x = util.dirac([1, 3], device=device, dtype=dtype)
+                        W = xp.ones([1, 3], dtype=dtype)
+                        y = backend.to_device(conv.convolve(
+                            x, W, mode=mode))
+                        npt.assert_allclose(y, [[1]], atol=1e-5)
 
-                    x = util.dirac([1, 3], device=device, dtype=dtype)
-                    W = xp.ones([1, 2], dtype=dtype)
-                    y = backend.to_device(conv.convolve(
-                        x, W, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(y, [[1, 1]], atol=1e-5)
+                        x = util.dirac([1, 3], device=device, dtype=dtype)
+                        W = xp.ones([1, 2], dtype=dtype)
+                        y = backend.to_device(conv.convolve(
+                            x, W, mode=mode))
+                        npt.assert_allclose(y, [[1, 1]], atol=1e-5)
 
-                    x = util.dirac([1, 3], device=device, dtype=dtype)
-                    W = xp.ones([2, 1, 3], dtype=dtype)
-                    y = backend.to_device(
-                        conv.convolve(
-                            x,
-                            W,
-                            mode=mode,
-                            output_multi_channel=True),
-                        backend.cpu_device)
-                    npt.assert_allclose(y, [[[1]],
-                                            [[1]]], atol=1e-5)
+                        x = util.dirac([1, 3], device=device, dtype=dtype)
+                        W = xp.ones([2, 1, 3], dtype=dtype)
+                        y = backend.to_device(
+                            conv.convolve(
+                                x,
+                                W,
+                                mode=mode,
+                                output_multi_channel=True),
+                            backend.cpu_device)
+                        npt.assert_allclose(y, [[[1]],
+                                                [[1]]], atol=1e-5)
 
     def test_convolve_full(self):
         mode = 'full'
@@ -56,29 +58,67 @@ class TestConv(unittest.TestCase):
             with device:
                 for dtype in [np.float32, np.float64,
                               np.complex64, np.complex128]:
-                    x = util.dirac([1, 3], device=device, dtype=dtype)
-                    W = xp.ones([1, 3], dtype=dtype)
-                    y = backend.to_device(conv.convolve(
-                        x, W, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(y, [[0, 1, 1, 1, 0]], atol=1e-5)
+                    with self.subTest(dtype=dtype, device=device):
+                        x = util.dirac([1, 3], device=device, dtype=dtype)
+                        W = xp.ones([1, 3], dtype=dtype)
+                        y = backend.to_device(conv.convolve(
+                            x, W, mode=mode))
+                        npt.assert_allclose(y, [[0, 1, 1, 1, 0]], atol=1e-5)
 
-                    x = util.dirac([1, 3], device=device, dtype=dtype)
-                    W = xp.ones([1, 2], dtype=dtype)
-                    y = backend.to_device(conv.convolve(
-                        x, W, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(y, [[0, 1, 1, 0]], atol=1e-5)
+                        x = util.dirac([1, 3], device=device, dtype=dtype)
+                        W = xp.ones([1, 2], dtype=dtype)
+                        y = backend.to_device(conv.convolve(
+                            x, W, mode=mode))
+                        npt.assert_allclose(y, [[0, 1, 1, 0]], atol=1e-5)
 
-                    x = util.dirac([1, 3], device=device, dtype=dtype)
-                    W = xp.ones([2, 1, 3], dtype=dtype)
-                    y = backend.to_device(
-                        conv.convolve(
-                            x,
-                            W,
-                            mode=mode,
-                            output_multi_channel=True),
-                        backend.cpu_device)
-                    npt.assert_allclose(y, [[[0, 1, 1, 1, 0]],
-                                            [[0, 1, 1, 1, 0]]], atol=1e-5)
+                        x = util.dirac([1, 3], device=device, dtype=dtype)
+                        W = xp.ones([2, 1, 3], dtype=dtype)
+                        y = backend.to_device(
+                            conv.convolve(
+                                x,
+                                W,
+                                mode=mode,
+                                output_multi_channel=True),
+                            backend.cpu_device)
+                        npt.assert_allclose(y, [[[0, 1, 1, 1, 0]],
+                                                [[0, 1, 1, 1, 0]]], atol=1e-5)
+
+    def test_convolve_strides(self):
+        mode = 'full'
+        devices = [backend.cpu_device]
+        if config.cupy_enabled:
+            devices.append(backend.Device(0))
+
+        strides = (1, 2)
+        for device in devices:
+            for dtype in [np.float32, np.float64,
+                          np.complex64, np.complex128]:
+                with self.subTest(device=device, dtype=dtype):
+                    xp = device.xp
+                    with device:
+                        x = util.dirac([1, 3], device=device, dtype=dtype)
+                        W = xp.ones([1, 3], dtype=dtype)
+                        y = backend.to_device(conv.convolve(
+                            x, W, mode=mode, strides=strides))
+                        npt.assert_allclose(y, [[0, 1, 0]], atol=1e-5)
+
+                        x = util.dirac([1, 3], device=device, dtype=dtype)
+                        W = xp.ones([1, 2], dtype=dtype)
+                        y = backend.to_device(conv.convolve(
+                            x, W, mode=mode, strides=strides))
+                        npt.assert_allclose(y, [[0, 1]], atol=1e-5)
+
+                        x = util.dirac([1, 3], device=device, dtype=dtype)
+                        W = xp.ones([2, 1, 3], dtype=dtype)
+                        y = backend.to_device(
+                            conv.convolve(
+                                x,
+                                W,
+                                mode=mode,
+                                strides=strides,
+                                output_multi_channel=True))
+                        npt.assert_allclose(y, [[[0, 1, 0]],
+                                                [[0, 1, 0]]], atol=1e-5)
 
     def test_convolve_adjoint_input_valid(self):
         mode = 'valid'
@@ -91,28 +131,29 @@ class TestConv(unittest.TestCase):
             with device:
                 for dtype in [np.float32, np.float64,
                               np.complex64, np.complex128]:
-                    y = xp.ones([1, 1], dtype=dtype)
-                    W = xp.ones([1, 3], dtype=dtype)
-                    x = backend.to_device(conv.convolve_adjoint_input(
-                        W, y, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(x, [[1, 1, 1]], atol=1e-5)
+                    with self.subTest(dtype=dtype, device=device):
+                        y = xp.ones([1, 1], dtype=dtype)
+                        W = xp.ones([1, 3], dtype=dtype)
+                        x = backend.to_device(conv.convolve_adjoint_input(
+                            W, y, mode=mode))
+                        npt.assert_allclose(x, [[1, 1, 1]], atol=1e-5)
 
-                    y = xp.ones([1, 2], dtype=dtype)
-                    W = xp.ones([1, 2], dtype=dtype)
-                    x = backend.to_device(conv.convolve_adjoint_input(
-                        W, y, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(x, [[1, 2, 1]], atol=1e-5)
+                        y = xp.ones([1, 2], dtype=dtype)
+                        W = xp.ones([1, 2], dtype=dtype)
+                        x = backend.to_device(conv.convolve_adjoint_input(
+                            W, y, mode=mode))
+                        npt.assert_allclose(x, [[1, 2, 1]], atol=1e-5)
 
-                    y = xp.ones([2, 1, 1], dtype=dtype)
-                    W = xp.ones([2, 1, 3], dtype=dtype)
-                    x = backend.to_device(
-                        conv.convolve_adjoint_input(
-                            W,
-                            y,
-                            mode=mode,
-                            output_multi_channel=True),
-                        backend.cpu_device)
-                    npt.assert_allclose(x, [[2, 2, 2]], atol=1e-5)
+                        y = xp.ones([2, 1, 1], dtype=dtype)
+                        W = xp.ones([2, 1, 3], dtype=dtype)
+                        x = backend.to_device(
+                            conv.convolve_adjoint_input(
+                                W,
+                                y,
+                                mode=mode,
+                                output_multi_channel=True),
+                            backend.cpu_device)
+                        npt.assert_allclose(x, [[2, 2, 2]], atol=1e-5)
 
     def test_convolve_adjoint_input_full(self):
         mode = 'full'
@@ -125,29 +166,30 @@ class TestConv(unittest.TestCase):
             with device:
                 for dtype in [np.float32, np.float64,
                               np.complex64, np.complex128]:
-                    y = xp.ones([1, 5], dtype=dtype)
-                    W = xp.ones([1, 3], dtype=dtype)
-                    x = backend.to_device(conv.convolve_adjoint_input(
-                        W, y, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(x, [[3, 3, 3]], atol=1e-5)
+                    with self.subTest(dtype=dtype, device=device):
+                        y = xp.ones([1, 5], dtype=dtype)
+                        W = xp.ones([1, 3], dtype=dtype)
+                        x = backend.to_device(conv.convolve_adjoint_input(
+                            W, y, mode=mode))
+                        npt.assert_allclose(x, [[3, 3, 3]], atol=1e-5)
 
-                    y = xp.ones([1, 4], dtype=dtype)
-                    W = xp.ones([1, 2], dtype=dtype)
-                    x = backend.to_device(
-                        conv.convolve_adjoint_input(
-                            W, y, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(x, [[2, 2, 2]], atol=1e-5)
+                        y = xp.ones([1, 4], dtype=dtype)
+                        W = xp.ones([1, 2], dtype=dtype)
+                        x = backend.to_device(
+                            conv.convolve_adjoint_input(
+                                W, y, mode=mode))
+                        npt.assert_allclose(x, [[2, 2, 2]], atol=1e-5)
 
-                    y = xp.ones([2, 1, 5], dtype=dtype)
-                    W = xp.ones([2, 1, 3], dtype=dtype)
-                    x = backend.to_device(
-                        conv.convolve_adjoint_input(
-                            W,
-                            y,
-                            mode=mode,
-                            output_multi_channel=True),
-                        backend.cpu_device)
-                    npt.assert_allclose(x, [[6, 6, 6]], atol=1e-5)
+                        y = xp.ones([2, 1, 5], dtype=dtype)
+                        W = xp.ones([2, 1, 3], dtype=dtype)
+                        x = backend.to_device(
+                            conv.convolve_adjoint_input(
+                                W,
+                                y,
+                                mode=mode,
+                                output_multi_channel=True),
+                            backend.cpu_device)
+                        npt.assert_allclose(x, [[6, 6, 6]], atol=1e-5)
 
     def test_convolve_adjoint_filter_valid(self):
         mode = 'valid'
@@ -161,32 +203,33 @@ class TestConv(unittest.TestCase):
             with device:
                 for dtype in [np.float32, np.float64,
                               np.complex64, np.complex128]:
-                    x = xp.ones([1, 3], dtype=dtype)
-                    y = xp.ones([1, 1], dtype=dtype)
-                    W = backend.to_device(
-                        conv.convolve_adjoint_filter(
-                            x, y, ndim, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(W, [[1, 1, 1]], atol=1e-5)
+                    with self.subTest(dtype=dtype, device=device):
+                        x = xp.ones([1, 3], dtype=dtype)
+                        y = xp.ones([1, 1], dtype=dtype)
+                        W = backend.to_device(
+                            conv.convolve_adjoint_filter(
+                                x, y, ndim, mode=mode))
+                        npt.assert_allclose(W, [[1, 1, 1]], atol=1e-5)
 
-                    x = xp.ones([1, 3], dtype=dtype)
-                    y = xp.ones([1, 2], dtype=dtype)
-                    W = backend.to_device(
-                        conv.convolve_adjoint_filter(
-                            x, y, ndim, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(W, [[2, 2]], atol=1e-5)
+                        x = xp.ones([1, 3], dtype=dtype)
+                        y = xp.ones([1, 2], dtype=dtype)
+                        W = backend.to_device(
+                            conv.convolve_adjoint_filter(
+                                x, y, ndim, mode=mode))
+                        npt.assert_allclose(W, [[2, 2]], atol=1e-5)
 
-                    x = xp.ones([1, 1, 3], dtype=dtype)
-                    y = xp.ones([2, 1, 1], dtype=dtype)
-                    W = backend.to_device(
-                        conv.convolve_adjoint_filter(
-                            x,
-                            y,
-                            ndim,
-                            mode=mode,
-                            output_multi_channel=True),
-                        backend.cpu_device)
-                    npt.assert_allclose(W, [[[1, 1, 1]],
-                                            [[1, 1, 1]]], atol=1e-5)
+                        x = xp.ones([1, 1, 3], dtype=dtype)
+                        y = xp.ones([2, 1, 1], dtype=dtype)
+                        W = backend.to_device(
+                            conv.convolve_adjoint_filter(
+                                x,
+                                y,
+                                ndim,
+                                mode=mode,
+                                output_multi_channel=True),
+                            backend.cpu_device)
+                        npt.assert_allclose(W, [[[1, 1, 1]],
+                                                [[1, 1, 1]]], atol=1e-5)
 
     def test_convolve_adjoint_filter_full(self):
         mode = 'full'
@@ -200,29 +243,30 @@ class TestConv(unittest.TestCase):
             with device:
                 for dtype in [np.float32, np.float64,
                               np.complex64, np.complex128]:
-                    x = xp.ones([1, 3], dtype=dtype)
-                    y = xp.ones([1, 5], dtype=dtype)
-                    W = backend.to_device(
-                        conv.convolve_adjoint_filter(
-                            x, y, ndim, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(W, [[3, 3, 3]], atol=1e-5)
+                    with self.subTest(dtype=dtype, device=device):
+                        x = xp.ones([1, 3], dtype=dtype)
+                        y = xp.ones([1, 5], dtype=dtype)
+                        W = backend.to_device(
+                            conv.convolve_adjoint_filter(
+                                x, y, ndim, mode=mode))
+                        npt.assert_allclose(W, [[3, 3, 3]], atol=1e-5)
 
-                    x = xp.ones([1, 3], dtype=dtype)
-                    y = xp.ones([1, 4], dtype=dtype)
-                    W = backend.to_device(
-                        conv.convolve_adjoint_filter(
-                            x, y, ndim, mode=mode), backend.cpu_device)
-                    npt.assert_allclose(W, [[3, 3]], atol=1e-5)
+                        x = xp.ones([1, 3], dtype=dtype)
+                        y = xp.ones([1, 4], dtype=dtype)
+                        W = backend.to_device(
+                            conv.convolve_adjoint_filter(
+                                x, y, ndim, mode=mode))
+                        npt.assert_allclose(W, [[3, 3]], atol=1e-5)
 
-                    x = xp.ones([1, 1, 3], dtype=dtype)
-                    y = xp.ones([2, 1, 5], dtype=dtype)
-                    W = backend.to_device(
-                        conv.convolve_adjoint_filter(
-                            x,
-                            y,
-                            ndim,
-                            mode=mode,
-                            output_multi_channel=True),
-                        backend.cpu_device)
-                    npt.assert_allclose(W, [[[3, 3, 3]],
-                                            [[3, 3, 3]]], atol=1e-5)
+                        x = xp.ones([1, 1, 3], dtype=dtype)
+                        y = xp.ones([2, 1, 5], dtype=dtype)
+                        W = backend.to_device(
+                            conv.convolve_adjoint_filter(
+                                x,
+                                y,
+                                ndim,
+                                mode=mode,
+                                output_multi_channel=True),
+                            backend.cpu_device)
+                        npt.assert_allclose(W, [[[3, 3, 3]],
+                                                [[3, 3, 3]]], atol=1e-5)

--- a/tests/test_linop.py
+++ b/tests/test_linop.py
@@ -469,6 +469,17 @@ class TestLinop(unittest.TestCase):
                         self.check_linop_adjoint(A, dtype=dtype, device=device)
                         self.check_linop_pickleable(A)
 
+                        data_shape = [2, 3, 4]
+                        filt = util.randn([4, 2, 2, 3], dtype=dtype)
+                        strides = [2, 2]
+                        A = linop.ConvolveData(
+                            data_shape, filt,
+                            mode=mode, strides=strides,
+                            multi_channel=True)
+                        self.check_linop_linear(A, dtype=dtype, device=device)
+                        self.check_linop_adjoint(A, dtype=dtype, device=device)
+                        self.check_linop_pickleable(A)
+
     def test_ConvolveFilter(self):
         for device in devices:
             for dtype in dtypes:
@@ -502,6 +513,17 @@ class TestLinop(unittest.TestCase):
                         A = linop.ConvolveFilter(
                             filt_shape, data,
                             mode=mode,
+                            multi_channel=True)
+                        self.check_linop_linear(A, dtype=dtype, device=device)
+                        self.check_linop_adjoint(A, dtype=dtype, device=device)
+                        self.check_linop_pickleable(A)
+
+                        filt_shape = [4, 2, 2, 3]
+                        strides = [2, 2]
+                        data = util.randn([2, 3, 4], dtype=dtype)
+                        A = linop.ConvolveFilter(
+                            filt_shape, data,
+                            mode=mode, strides=strides,
                             multi_channel=True)
                         self.check_linop_linear(A, dtype=dtype, device=device)
                         self.check_linop_adjoint(A, dtype=dtype, device=device)


### PR DESCRIPTION
Support strides in convolution functions.
Combine input/output multi_channel options to one option.
Use scipy.signal.convolve for CPU which selects fastest method instead of only fft_convolve.
Move to CPU and use scipy convolution when cudnn is not enabled.