### PR TITLE
Restructure interpolation

### DIFF
--- a/sigpy/interp.py
+++ b/sigpy/interp.py
@@ -14,7 +14,7 @@ KERNELS = ['spline', 'kaiser_bessel']
 
 
 def interpolate(input, coord, kernel='spline', width=2, param=1):
-    """Interpolation from array to points specified by coordinates.
+    r"""Interpolation from array to points specified by coordinates.
 
     Let :math:`x` be the input, :math:`y` be the output,
     :math:`c`: be the coordinates, :math:`W` be the width,
@@ -76,7 +76,7 @@ def interpolate(input, coord, kernel='spline', width=2, param=1):
 
 
 def gridding(input, coord, shape, kernel="spline", width=2, param=1):
-    """Gridding of points specified by coordinates to array.
+    r"""Gridding of points specified by coordinates to array.
 
     Let :math:`y` be the input, :math:`x` be the output,
     :math:`c`: be the coordinates, :math:`W` be the width,
@@ -373,17 +373,28 @@ if config.cupy_enabled:  # pragma: no cover
 
         x = beta * sqrt(1 - x * x);
         S t = x / 3.75;
-        if (x < 3.75)
-            return 1 + 3.5156229 * pow(t, 2) + 3.0899424 * pow(t, 4) +
-                1.2067492 * pow(t, 6) + 0.2659732 * pow(t, 8) +
-                0.0360768 * pow(t, 10) + 0.0045813 * pow(t, 12);
-        else
-            return pow(x, -0.5) * exp(x) * (
-                0.39894228 + 0.01328592 * pow(t, -1) +
-                0.00225319 * pow(t, -2) - 0.00157565 * pow(t, -3) +
-                0.00916281 * pow(t, -4) - 0.02057706 * pow(t, -5) +
-                0.02635537 * pow(t, -6) - 0.01647633 * pow(t, -7) +
-                0.00392377 * pow(t, -8));
+        S t2 = t * t;
+        S t4 = t2 * t2;
+        S t6 = t4 * t4;
+        S t8 = t6 * t2;
+        if (x < 3.75) {
+            S t10 = t8 * t2;
+            S t12 = t10 * t2;
+            return 1 + 3.5156229 * t2 + 3.0899424 * t4 +
+                1.2067492 * t6 + 0.2659732 * t8 +
+                0.0360768 * t10 + 0.0045813 * t12;
+        } else {
+            S t3 = t * t2;
+            S t5 = t3 * t2;
+            S t7 = t5 * t2;
+
+            return exp(x) / sqrt(x) * (
+                0.39894228 + 0.01328592 / t +
+                0.00225319 / t2 - 0.00157565 / t3 +
+                0.00916281 / t4 - 0.02057706 / t5 +
+                0.02635537 / t6 - 0.01647633 / t7 +
+                0.00392377 / t8);
+        }
     }
     """
 

--- a/sigpy/interp.py
+++ b/sigpy/interp.py
@@ -251,7 +251,8 @@ def _get_interpolate(kernel):
                         w = wy * kernel((x - kx) / (width / 2), param)
 
                         for b in range(batch_size):
-                            output[b, i] += w * input[b, z % nz, y % ny, x % nx]
+                            output[b, i] += w * input[
+                                b, z % nz, y % ny, x % nx]
 
         return output
 
@@ -338,7 +339,8 @@ def _get_gridding(kernel):
                         w = wy * kernel((x - kx) / (width / 2), param)
 
                         for b in range(batch_size):
-                            output[b, z % nz, y % ny, x % nx] += w * input[b, i]
+                            output[b, z % nz, y % ny, x % nx] += w * input[
+                                b, i]
 
         return output
 
@@ -622,8 +624,8 @@ if config.cupy_enabled:  # pragma: no cover
                         for (int b = 0; b < batch_size; b++) {
                             const int input_idx[] = {b, i};
                             const T v = (T) w * input[input_idx];
-                            const int output_idx[] = {b, mod(z, nz), mod(y, ny),
-                                mod(x, nx)};
+                            const int output_idx[] = {
+                                b, mod(z, nz), mod(y, ny), mod(x, nx)};
                             atomicAdd(&output[output_idx], v);
                         }
                     }
@@ -748,8 +750,8 @@ if config.cupy_enabled:  # pragma: no cover
                         for (int b = 0; b < batch_size; b++) {
                             const int input_idx[] = {b, i};
                             const T v = (T) w * input[input_idx];
-                            const int output_idx[] = {b, mod(z, nz), mod(y, ny),
-                                mod(x, nx)};
+                            const int output_idx[] = {
+                                b, mod(z, nz), mod(y, ny), mod(x, nx)};
                             atomicAdd(reinterpret_cast<T::value_type*>(
                                 &(output[output_idx])), v.real());
                             atomicAdd(reinterpret_cast<T::value_type*>(

--- a/sigpy/interp.py
+++ b/sigpy/interp.py
@@ -24,13 +24,13 @@ def interpolate(input, coord, kernel='spline', width=2, param=1):
         y[j] = \sum_{i : \| i - c[j] \|_\inf \leq W / 2}
                K((i - c[j]) / (W / 2)) x[i]
 
-    There are two types of kernels: "spline" and "kaiser_bessel".
+    There are two types of kernels: 'spline' and 'kaiser_bessel'.
 
-    "spline" uses the cardinal B-spline functions as kernels.
-    For example, kernel="spline" and param=1 performs linear interpolation.
+    'spline' uses the cardinal B-spline functions as kernels.
+    For example, kernel='spline' and param=1 performs linear interpolation.
     See the reference wikipedia page for the function expressions.
 
-    "kaiser_bessel" uses the Kaiser-Bessel function as kernel.
+    'kaiser_bessel' uses the Kaiser-Bessel function as kernel.
     It considers :math:`K(x) = I_0(\beta \sqrt{1 - (x^2})`
     for x between -1 and 1, where :math:`I_0` is the modified
     Bessel function of the first kind. Otherwise, returns 0.
@@ -42,7 +42,7 @@ def interpolate(input, coord, kernel='spline', width=2, param=1):
         input (array): Input array of shape.
         coord (array): Coordinate array of shape [..., ndim]
         width (float): Interpolation kernel full-width.
-        kernel (str): Interpolation kernel, {"spline", "kaiser_bessel"}.
+        kernel (str): Interpolation kernel, {'spline', 'kaiser_bessel'}.
         param (float): Kernel parameter.
 
     Returns:

--- a/sigpy/mri/dcf.py
+++ b/sigpy/mri/dcf.py
@@ -47,12 +47,8 @@ def pipe_menon_dcf(coord, device=sp.cpu_device, max_iter=30,
         w = xp.ones(coord.shape[:-1], dtype=coord.dtype)
         img_shape = sp.estimate_shape(coord)
 
-        # Get kernel
-        x = xp.arange(n, dtype=coord.dtype) / n
-        kernel = xp.i0(beta * (1 - x**2)**0.5).astype(coord.dtype)
-        kernel /= kernel.max()
-
-        G = sp.linop.Gridding(img_shape, coord, width, kernel)
+        G = sp.linop.Gridding(img_shape, coord, param=beta,
+                              width=width, kernel='kaiser_bessel')
         with tqdm(total=max_iter, desc="PipeMenonDCF",
                   disable=not show_pbar) as pbar:
             for it in range(max_iter):

--- a/tests/test_interp.py
+++ b/tests/test_interp.py
@@ -19,20 +19,19 @@ class TestInterp(unittest.TestCase):
         batch = 2
         for xp in xps:
             for ndim in [1, 2, 3]:
-                with self.subTest(ndim=ndim, xp=xp):
-                    shape = [3] + [1] * (ndim - 1)
-                    width = 2.0
-                    kernel = xp.array([1.0, 0.5])
-                    coord = xp.array([[0.1] + [0] * (ndim - 1),
-                                      [1.1] + [0] * (ndim - 1),
-                                      [2.1] + [0] * (ndim - 1)])
+                for dtype in [np.float32, np.complex64]:
+                    with self.subTest(ndim=ndim, xp=xp, dtype=dtype):
+                        shape = [3] + [1] * (ndim - 1)
+                        coord = xp.array([[0.1] + [0] * (ndim - 1),
+                                          [1.1] + [0] * (ndim - 1),
+                                          [2.1] + [0] * (ndim - 1)])
 
-                    input = xp.array([[0, 1.0, 0]] * batch).reshape(
-                        [batch] + shape)
-                    output = interp.interpolate(input, width, kernel, coord)
-                    output_expected = xp.array([[0.1, 0.9, 0]] * batch)
-                    xp.testing.assert_allclose(output, output_expected,
-                                               atol=1e-7)
+                        input = xp.array([[0, 1.0, 0]] * batch, dtype=dtype)
+                        input = input.reshape([batch] + shape)
+                        output = interp.interpolate(input, coord)
+                        output_expected = xp.array([[0.1, 0.9, 0]] * batch)
+                        xp.testing.assert_allclose(output, output_expected,
+                                                   atol=1e-7)
 
     def test_gridding(self):
         xps = [np]
@@ -42,18 +41,16 @@ class TestInterp(unittest.TestCase):
         batch = 2
         for xp in xps:
             for ndim in [1, 2, 3]:
-                with self.subTest(ndim=ndim, xp=xp):
-                    shape = [3] + [1] * (ndim - 1)
-                    width = 2.0
-                    kernel = xp.array([1.0, 0.5])
-                    coord = xp.array([[0.1] + [0] * (ndim - 1),
-                                      [1.1] + [0] * (ndim - 1),
-                                      [2.1] + [0] * (ndim - 1)])
+                for dtype in [np.float32, np.complex64]:
+                    with self.subTest(ndim=ndim, xp=xp, dtype=dtype):
+                        shape = [3] + [1] * (ndim - 1)
+                        coord = xp.array([[0.1] + [0] * (ndim - 1),
+                                          [1.1] + [0] * (ndim - 1),
+                                          [2.1] + [0] * (ndim - 1)])
 
-                    input = xp.array([[0, 1.0, 0]] * batch)
-                    output = interp.gridding(
-                        input, [batch] + shape, width, kernel, coord)
-                    output_expected = xp.array(
-                        [[0, 0.9, 0.1]] * batch).reshape([batch] + shape)
-                    xp.testing.assert_allclose(output, output_expected,
-                                               atol=1e-7)
+                        input = xp.array([[0, 1.0, 0]] * batch, dtype=dtype)
+                        output = interp.gridding(input, coord, [batch] + shape)
+                        output_expected = xp.array(
+                            [[0, 0.9, 0.1]] * batch).reshape([batch] + shape)
+                        xp.testing.assert_allclose(output, output_expected,
+                                                   atol=1e-7)

--- a/tests/test_linop.py
+++ b/tests/test_linop.py
@@ -306,12 +306,10 @@ class TestLinop(unittest.TestCase):
     def test_Interpolate(self):
 
         # Test linear interpolation.
-        width = 2.0
         ishape = [5]
         coord = np.array([[0.5], [1.5], [2.5]])
-        kernel = [1.0, 0.5]
 
-        A = linop.Interpolate(ishape, coord, width, kernel)
+        A = linop.Interpolate(ishape, coord)
         self.check_linop_adjoint(A)
         self.check_linop_linear(A)
         self.check_linop_pickleable(A)
@@ -326,7 +324,7 @@ class TestLinop(unittest.TestCase):
                           [1, 0],
                           [1.5, 0]]) / 4.0
 
-        A = linop.Interpolate(ishape, coord, width, kernel)
+        A = linop.Interpolate(ishape, coord)
         self.check_linop_adjoint(A)
         self.check_linop_linear(A)
         self.check_linop_pickleable(A)
@@ -334,7 +332,7 @@ class TestLinop(unittest.TestCase):
         # Test batch
         ishape = [2, 2, 2]
 
-        A = linop.Interpolate(ishape, coord, width, kernel)
+        A = linop.Interpolate(ishape, coord)
         self.check_linop_adjoint(A)
         self.check_linop_linear(A)
         self.check_linop_pickleable(A)


### PR DESCRIPTION
The old version of interpolate and gridding used a discretized array to specify the kernel. Linear interpolation was then used to compute continuous interpolation weights from the array. This introduces errors and is not intuitive to use. For example, both [1, 0] and [1, 0.5, 0] specify linear interpolation.

The new version accepts the kernel name as argument and evaluate the kernel function internally. In particular, the functions implement `spline` and `kaiser_bessel` kernels. In addition, a `param` argument is added to specify kernel parameters. For `spline`, it specifies the order, and for `kaiser_bessel`, it specifies the beta parameter. In particular, `spline` with `param=1` performs linear interpolation.