### PR TITLE
Improved FiniteDifference by removing unnecessary calls over extra axes

### DIFF
--- a/sigpy/linop.py
+++ b/sigpy/linop.py
@@ -1377,15 +1377,17 @@ def FiniteDifference(ishape, axes=None):
     """Linear operator that computes finite difference gradient.
 
     Args:
-       ishape (tuple of ints): Input shape.
+        ishape (tuple of ints): Input shape.
+        axes (tuple or list): Axes to circularly shift. All axes are used if
+            None.
 
     """
     I = Identity(ishape)
-    axes = util._normalize_axes(axes, len(ishape))
     ndim = len(ishape)
+    axes = util._normalize_axes(axes, ndim)
     linops = []
     for i in axes:
-        D = I - Circshift(ishape, [0] * i + [1] + [0] * (ndim - i - 1))
+        D = I - Circshift(ishape, [1], axes=[i])
         R = Reshape([1] + list(ishape), ishape)
         linops.append(R * D)
 


### PR DESCRIPTION
The current argument to Circshift will cause xp.roll to be called multiple extra times, with a shift of 0. This causes a slight decrease in speed. I have pasted a script that compares the current and the new implementation.
```python
import numpy as np

import sigpy as sp
from sigpy import util
from sigpy.linop import Identity, Circshift, Reshape, Vstack


# Proposed change to FiniteDifference
def FiniteDifference(ishape, axes=None):
    """Linear operator that computes finite difference gradient.

    Args:
        ishape (tuple of ints): Input shape.
        axes (tuple or list): Axes to circularly shift. All axes are used if
            None.

    """
    I = Identity(ishape)
    ndim = len(ishape)
    axes = util._normalize_axes(axes, ndim)
    linops = []
    for i in axes:
        D = I - Circshift(ishape, [1], axes=[i])
        R = Reshape([1] + list(ishape), ishape)
        linops.append(R * D)

    G = Vstack(linops, axis=0)

    return G


device = 0
ishape = (24, 512, 512)
axes = [1, 2]
num_trials = 5

# Create G using old
G = sp.linop.FiniteDifference(ishape, axes=axes)
with sp.Device(device):
    for _ in range(num_trials):
        max_eig_G = sp.app.MaxEig(G.H * G,
                                  dtype=np.complex64,
                                  device=device).run()

# New G
G = FiniteDifference(ishape, axes=axes)
with sp.Device(device):
    for _ in range(num_trials):
        max_eig_G = sp.app.MaxEig(G.H * G,
                                  dtype=np.complex64,
                                  device=device).run()
```