### PR TITLE
Fix device and dtypes

### DIFF
--- a/sigpy/alg.py
+++ b/sigpy/alg.py
@@ -193,7 +193,7 @@ class GradientMethod(Alg):
                 backend.copyto(self.z, self.x +
                                ((t_old - 1) / self.t) * (self.x - x_old))
 
-            self.resid = xp.linalg.norm(self.x - x_old).item() / self.alpha
+            self.resid = xp.linalg.norm((self.x - x_old) / self.alpha).item()
 
     def _done(self):
         return (self.iter >= self.max_iter) or self.resid <= self.tol

--- a/sigpy/alg.py
+++ b/sigpy/alg.py
@@ -338,11 +338,13 @@ class PrimalDualHybridGradient(Alg):
 
         if self.gamma_primal > 0:
             xp = self.x_device.xp
-            self.tau_min = xp.amin(xp.abs(tau)).item()
+            with self.x_device:
+                self.tau_min = xp.amin(xp.abs(tau)).item()
 
         if self.gamma_dual > 0:
             xp = self.u_device.xp
-            self.sigma_min = xp.amin(xp.abs(sigma)).item()
+            with self.u_device:
+                self.sigma_min = xp.amin(xp.abs(sigma)).item()
 
         self.resid = np.infty
 

--- a/sigpy/linop.py
+++ b/sigpy/linop.py
@@ -646,7 +646,8 @@ class Reshape(Linop):
         super().__init__(oshape, ishape)
 
     def _apply(self, input):
-        return input.reshape(self.oshape)
+        with backend.get_device(input):
+            return input.reshape(self.oshape)
 
     def _adjoint_linop(self):
         return Reshape(self.ishape, self.oshape)
@@ -1050,8 +1051,9 @@ class Resize(Linop):
         super().__init__(oshape, ishape)
 
     def _apply(self, input):
-        return util.resize(input, self.oshape,
-                           ishift=self.ishift, oshift=self.oshift)
+        with backend.get_device(input):
+            return util.resize(input, self.oshape,
+                               ishift=self.ishift, oshift=self.oshift)
 
     def _adjoint_linop(self):
         return Resize(self.ishape, self.oshape,

--- a/sigpy/prox.py
+++ b/sigpy/prox.py
@@ -114,7 +114,7 @@ class Stack(Prox):
 
     def _prox(self, alpha, input):
         with backend.get_device(input):
-            if np.isscalar(alpha):
+            if np.ndim(alpha) == 0:
                 alphas = [alpha] * self.nops
             else:
                 alphas = util.split(alpha, self.shapes)

--- a/sigpy/util.py
+++ b/sigpy/util.py
@@ -429,9 +429,8 @@ def axpy(y, a, x):
 
     Args:
         y (array): Output array.
-        a (scalar): Input scalar.
+        a (array): Input array.
         x (array): Input array.
-
     """
     xp = backend.get_array_module(y)
 
@@ -446,7 +445,7 @@ def xpay(y, a, x):
 
     Args:
         y (array): Output array.
-        a (scalar): Input scalar.
+        a (array): Input array.
         x (array): Input array.
     """
     xp = backend.get_array_module(y)
@@ -484,4 +483,4 @@ if config.cupy_enabled:  # pragma: no cover
         """
         y = x + (T) a * y;
         """,
-        name='axpy')
+        name='xpay')


### PR DESCRIPTION
It seems that the CuPy type-generic ElementwiseKernels (used for axpy and xpay) cannot figure out what to do with Python scalars. I get an error when using PDHG through the LinearLeastSquares app, when I let the app calculate what the step size should be. The step size is a Python scalar, which gets passed to the axpy function.

Prior to the change in https://github.com/mikgroup/sigpy/commit/02d3af4cd253792846e1bf6dc64d3c4688668ce6, scalars would be converted to 0-D CuPy arrays through `a = backend.to_device(a, device)`, causing no error, but that line is now removed.

I'm not sure what is the most desired fix, but I've changed the LinearLeastSquares app to create arrays instead of Python scalars every time it calculates a step size. Also, the following code should demonstrate the error in question. Note the CPU axpy does not have a problem accepting Python scalars.

```python
import traceback
import sigpy as sp
from sigpy import util


device = 0
arr_shape = (24, 256, 512)

device = sp.Device(device)
xp = device.xp

# Create inputs
with device:
    x = util.randn(arr_shape, dtype=xp.complex64, device=device)
    y = util.randn(arr_shape, dtype=xp.complex64, device=device)

    a = 2.4  # a is just a Python float
    # Should give error
    try:
        util.axpy(y, a, x)
    except Exception:
        print('----Error message:')
        traceback.print_exc()
        print('----')

    a = util.randn((1,), dtype=xp.complex64, device=device)  # a is an array
    # Shouldn't be an error
    util.axpy(y, a, x)
```