### PR TITLE
Fixed scalars being wrong input to ElementwiseKernels

### DIFF
--- a/sigpy/thresh.py
+++ b/sigpy/thresh.py
@@ -26,10 +26,14 @@ def soft_thresh(lamda, input):
         array: soft-thresholded result.
 
     """
-    xp = backend.get_array_module(input)
+    device = backend.get_device(input)
+    xp = device.xp
     if xp == np:
         return _soft_thresh(lamda, input)
     else:  # pragma: no cover
+        if np.isscalar(lamda):
+            lamda = backend.to_device(lamda, device)
+
         return _soft_thresh_cuda(lamda, input)
 
 
@@ -44,10 +48,14 @@ def hard_thresh(lamda, input):
         array: hard-thresholded result.
 
     """
-    xp = backend.get_array_module(input)
+    device = backend.get_device(input)
+    xp = device.xp
     if xp == np:
         return _hard_thresh(lamda, input)
     else:  # pragma: no cover
+        if np.isscalar(lamda):
+            lamda = backend.to_device(lamda, device)
+
         return _hard_thresh_cuda(lamda, input)
 
 

--- a/sigpy/util.py
+++ b/sigpy/util.py
@@ -429,15 +429,19 @@ def axpy(y, a, x):
 
     Args:
         y (array): Output array.
-        a (scalar): Input scalar.
+        a (scalar or array): Input scalar.
         x (array): Input array.
 
     """
-    xp = backend.get_array_module(y)
+    device = backend.get_device(y)
+    xp = device.xp
 
     if xp == np:
         _axpy(y, a, x, out=y)
     else:
+        if np.isscalar(a):
+            a = backend.to_device(a, device)
+
         _axpy_cuda(a, x, y)
 
 
@@ -446,14 +450,18 @@ def xpay(y, a, x):
 
     Args:
         y (array): Output array.
-        a (scalar): Input scalar.
+        a (scalar or array): Input scalar.
         x (array): Input array.
     """
-    xp = backend.get_array_module(y)
+    device = backend.get_device(y)
+    xp = device.xp
 
     if xp == np:
         _xpay(y, a, x, out=y)
     else:
+        if np.isscalar(a):
+            a = backend.to_device(a, device)
+
         _xpay_cuda(a, x, y)
 
 
@@ -484,4 +492,4 @@ if config.cupy_enabled:  # pragma: no cover
         """
         y = x + (T) a * y;
         """,
-        name='axpy')
+        name='xpay')


### PR DESCRIPTION
My other solution to the problem described in https://github.com/mikgroup/sigpy/pull/41 turned out to be not very robust. I was beginning to need to make too many changes to several other parts of the repo involving scalars. Changing the Python scalar to CuPy scalar array right before the ElementwiseKernel is simplest solution for now. A repo-wide change to scalars can be made later if desired.

The following code should show errors before merging my changes. And after merging, they should be gone.

```python
import traceback
import sigpy as sp
from sigpy import util


device = 2
arr_shape = (24, 256, 512)

device = sp.Device(device)
xp = device.xp

# Create inputs
with device:
    x = util.randn(arr_shape, dtype=xp.complex64, device=device)
    y = util.randn(arr_shape, dtype=xp.complex64, device=device)

    #### Testing axpy
    a = 2.4  # a is just a Python float
    # Should give error
    try:
        util.axpy(y, a, x)
    except Exception:
        print('----Error message:')
        traceback.print_exc()
        print('----')

    a = util.randn((1,), dtype=xp.complex64, device=device)  # a is an array
    # Shouldn't be an error
    util.axpy(y, a, x)

    a = xp.array(2.4)
    util.axpy(y, a, x)

    #### Testing xpay
    a = 2.4  # a is just a Python float
    # Should give error
    try:
        util.xpay(y, a, x)
    except Exception:
        print('----Error message:')
        traceback.print_exc()
        print('----')

    a = util.randn((1,), dtype=xp.complex64, device=device)  # a is an array
    # Shouldn't be an error
    util.xpay(y, a, x)

    a = xp.array(2.4)
    util.xpay(y, a, x)

    #### Testing soft_thresh
    lamda = 2.4  # lamda is just a Python float
    # Should give error
    try:
        _ = sp.thresh.soft_thresh(lamda, x)
    except Exception:
        print('----Error message:')
        traceback.print_exc()
        print('----')

    lamda = xp.array(2.4)  # Currently doesn't work for complex dtypes
    _ = sp.thresh.soft_thresh(lamda, x)

    #### Testing hard_thresh
    lamda = 2.4  # lamda is just a Python float
    # Should give error
    try:
        _ = sp.thresh.hard_thresh(lamda, x)
    except Exception:
        print('----Error message:')
        traceback.print_exc()
        print('----')

    lamda = xp.array(2.4)  # Currently doesn't work for complex dtypes
    _ = sp.thresh.hard_thresh(lamda, x)
```