### PR TITLE
poisson func output variable change

### DIFF
--- a/sigpy/mri/samp.py
+++ b/sigpy/mri/samp.py
@@ -57,7 +57,7 @@ def poisson(img_shape, accel, K=30, calib=[0, 0], dtype=np.complex,
 
     mask = mask.reshape(img_shape).astype(dtype)
     if return_density:
-        return mask, r
+        return mask, R
     else:
         return mask
 


### PR DESCRIPTION
In the poisson func:  the output variable that represents the density was changed - now the func returns R instead of r. That's because the inner function (_poisson) uses R for generating samples of rad.