### PR TITLE
Fix memory leak caused by alg referencing app object

### DIFF
--- a/sigpy/mri/app.py
+++ b/sigpy/mri/app.py
@@ -448,11 +448,11 @@ class EspiritCalib(sp.app.App):
             self.mps = xp.ones(ksp.shape[::-1] + (1, ), dtype=ksp.dtype)
 
             def forward(x):
-                with self.device:
+                with sp.get_device(x):
                     return AHA @ x
 
             def normalize(x):
-                with self.device:
+                with sp.get_device(x):
                     return xp.sum(xp.abs(x)**2,
                                   axis=-2, keepdims=True)**0.5
 


### PR DESCRIPTION
I found a memory leak in the ESPIRiT calibration app. When it's finished and dereferenced, it still uses some memory on GPU. I tracked down the problem to a reference to the ESPIRiT app that is passed to the PowerMethod alg.

The following code shows that there is memory that remains allocated even when the ESPIRiT app is done and no longer referenced.
```python
import numpy as np
import cupy as cp
import sigpy as sp
from sigpy.mri.app import EspiritCalib


def my_function():
    # Putting code in function so variables go out of scope automatically
    device = sp.Device(0)
    ksp = sp.util.randn((4, 128, 128, 128), dtype=np.complex64, device=device)

    app = EspiritCalib(ksp, device=device)

    mps = app.run()

    # app.alg = None  # This would release memory properly
    return


def print_mem():
    with cp.cuda.Device(0):
        mempool = cp.get_default_memory_pool()
        # Memory in MB
        used = mempool.used_bytes() / 1024 / 1024
        total = mempool.total_bytes() / 1024 / 1024
        print(used, 'MB USED')
        print(total, 'MB RESERVED')


print_mem()
my_function()
print_mem()

```
Dereferencing the alg manually can also correctly release the no longer used memory. With my fix in the PR, running the above code will show that memory used is 0 after the app is finished.

This might be related to https://github.com/mikgroup/sigpy/issues/49.