### PR TITLE
Add option to specify img_shape

### DIFF
--- a/sigpy/mri/app.py
+++ b/sigpy/mri/app.py
@@ -220,6 +220,7 @@ class JsenseRecon(sp.app.App):
         device (Device): device to perform reconstruction.
         weights (float or array): weights for data consistency.
         coord (None or array): coordinates.
+        img_shape (None or list): Image shape.
         max_iter (int): Maximum number of iterations.
         max_inner_iter (int): Maximum number of inner iterations.
 
@@ -239,7 +240,7 @@ class JsenseRecon(sp.app.App):
     def __init__(self, y,
                  mps_ker_width=16, ksp_calib_width=24,
                  lamda=0, device=sp.cpu_device, comm=None,
-                 weights=None, coord=None, max_iter=10,
+                 weights=None, coord=None, img_shape=None, max_iter=10,
                  max_inner_iter=10, normalize=True, show_pbar=True):
         self.y = y
         self.mps_ker_width = mps_ker_width
@@ -247,6 +248,7 @@ class JsenseRecon(sp.app.App):
         self.lamda = lamda
         self.weights = weights
         self.coord = coord
+        self.img_shape = img_shape
         self.max_iter = max_iter
         self.max_inner_iter = max_inner_iter
         self.normalize = normalize
@@ -276,7 +278,11 @@ class JsenseRecon(sp.app.App):
                     self.weights, ndim * [self.ksp_calib_width])
 
         else:
-            self.img_shape = sp.estimate_shape(self.coord)
+            if self.img_shape is None:
+                self.img_shape = sp.estimate_shape(self.coord)
+            else:
+                self.img_shape = list(self.img_shape)
+
             calib_idx = np.amax(np.abs(self.coord), axis=-
                                 1) < self.ksp_calib_width / 2
 

--- a/sigpy/mri/app.py
+++ b/sigpy/mri/app.py
@@ -221,6 +221,7 @@ class JsenseRecon(sp.app.App):
         weights (float or array): weights for data consistency.
         coord (None or array): coordinates.
         img_shape (None or list): Image shape.
+        grd_shape (None or list): Shape of grid.
         max_iter (int): Maximum number of iterations.
         max_inner_iter (int): Maximum number of inner iterations.
 
@@ -240,8 +241,9 @@ class JsenseRecon(sp.app.App):
     def __init__(self, y,
                  mps_ker_width=16, ksp_calib_width=24,
                  lamda=0, device=sp.cpu_device, comm=None,
-                 weights=None, coord=None, img_shape=None, max_iter=10,
-                 max_inner_iter=10, normalize=True, show_pbar=True):
+                 weights=None, coord=None, img_shape=None, grd_shape=None,
+                 max_iter=10, max_inner_iter=10, normalize=True,
+                 show_pbar=True):
         self.y = y
         self.mps_ker_width = mps_ker_width
         self.ksp_calib_width = ksp_calib_width
@@ -249,6 +251,7 @@ class JsenseRecon(sp.app.App):
         self.weights = weights
         self.coord = coord
         self.img_shape = img_shape
+        self.grd_shape = grd_shape
         self.max_iter = max_iter
         self.max_inner_iter = max_inner_iter
         self.normalize = normalize
@@ -317,8 +320,11 @@ class JsenseRecon(sp.app.App):
             img_ker_shape = [i + self.mps_ker_width -
                              1 for i in self.y.shape[1:]]
         else:
-            grd_shape = sp.estimate_shape(self.coord)
-            img_ker_shape = [i + self.mps_ker_width - 1 for i in grd_shape]
+            if self.grd_shape is None:
+                self.grd_shape = sp.estimate_shape(self.coord)
+
+            img_ker_shape = [i + self.mps_ker_width - 1
+                             for i in self.grd_shape]
 
         self.img_ker = sp.dirac(
             img_ker_shape, dtype=self.dtype, device=self.device)

--- a/sigpy/mri/dcf.py
+++ b/sigpy/mri/dcf.py
@@ -8,7 +8,7 @@ from tqdm.auto import tqdm
 __all__ = ['pipe_menon_dcf']
 
 
-def pipe_menon_dcf(coord, device=sp.cpu_device, max_iter=30,
+def pipe_menon_dcf(coord, img_shape=None, device=sp.cpu_device, max_iter=30,
                    n=128, beta=8, width=4, show_pbar=True):
     r"""Compute Pipe Menon density compensation factor.
 
@@ -22,6 +22,7 @@ def pipe_menon_dcf(coord, device=sp.cpu_device, max_iter=30,
 
     Args:
         coord (array): k-space coordinates.
+        img_shape (None or list): Image shape.
         device (Device): computing device.
         max_iter (int): number of iterations.
         n (int): Kaiser-Bessel sampling numbers for gridding operator.
@@ -45,7 +46,8 @@ def pipe_menon_dcf(coord, device=sp.cpu_device, max_iter=30,
 
     with device:
         w = xp.ones(coord.shape[:-1], dtype=coord.dtype)
-        img_shape = sp.estimate_shape(coord)
+        if img_shape is None:
+            img_shape = sp.estimate_shape(coord)
 
         G = sp.linop.Gridding(img_shape, coord, param=beta,
                               width=width, kernel='kaiser_bessel')

--- a/sigpy/mri/linop.py
+++ b/sigpy/mri/linop.py
@@ -101,13 +101,15 @@ def Sense(mps, coord=None, weights=None, tseg=None, ishape=None,
     return A
 
 
-def ConvSense(img_ker_shape, mps_ker, coord=None, weights=None, comm=None):
+def ConvSense(img_ker_shape, mps_ker, coord=None, weights=None, grd_shape=None,
+              comm=None):
     """Convolution linear operator with sensitivity maps kernel in k-space.
 
     Args:
         img_ker_shape (tuple of ints): image kernel shape.
         mps_ker (array): sensitivity maps kernel.
         coord (array): coordinates.
+        grd_shape (None or list): Shape of grid.
 
     """
     ndim = len(img_ker_shape)
@@ -119,7 +121,12 @@ def ConvSense(img_ker_shape, mps_ker, coord=None, weights=None, comm=None):
     A = C * R
 
     if coord is not None:
-        grd_shape = [num_coils] + sp.estimate_shape(coord)
+        if grd_shape is None:
+            grd_shape = sp.estimate_shape(coord)
+        else:
+            grd_shape = list(grd_shape)
+
+        grd_shape = [num_coils] + grd_shape
         iF = sp.linop.IFFT(grd_shape, axes=range(-ndim, 0))
         N = sp.linop.NUFFT(grd_shape, coord)
         A = N * iF * A
@@ -137,13 +144,15 @@ def ConvSense(img_ker_shape, mps_ker, coord=None, weights=None, comm=None):
     return A
 
 
-def ConvImage(mps_ker_shape, img_ker, coord=None, weights=None):
+def ConvImage(mps_ker_shape, img_ker, coord=None, weights=None,
+              grd_shape=None):
     """Convolution linear operator with image kernel in k-space.
 
     Args:
         mps_ker_shape (tuple of ints): sensitivity maps kernel shape.
         img_ker (array): image kernel.
         coord (array): coordinates.
+        grd_shape (None or list): Shape of grid.
 
     """
     ndim = img_ker.ndim
@@ -157,7 +166,12 @@ def ConvImage(mps_ker_shape, img_ker, coord=None, weights=None):
 
     if coord is not None:
         num_coils = mps_ker_shape[0]
-        grd_shape = [num_coils] + sp.estimate_shape(coord)
+        if grd_shape is None:
+            grd_shape = sp.estimate_shape(coord)
+        else:
+            grd_shape = list(grd_shape)
+
+        grd_shape = [num_coils] + grd_shape
         iF = sp.linop.IFFT(grd_shape, axes=range(-ndim, 0))
         N = sp.linop.NUFFT(grd_shape, coord)
         A = N * iF * A


### PR DESCRIPTION
This change allows users to specify image shape instead of relying on `estimate_shape`, which may produce shapes that aren't what the user expects. The option to specify image shape has been added to `JsenseRecon` and `pipe_menon_dcf`.

However, the `estimate_shape` function is still being used to estimate `grd_shape` in three places (all related to JSENSE):
https://github.com/mikgroup/sigpy/blob/8c25c53a15b99643be7adcdc351f7ba55fcea649/sigpy/mri/app.py#L314
https://github.com/mikgroup/sigpy/blob/8c25c53a15b99643be7adcdc351f7ba55fcea649/sigpy/mri/linop.py#L122
https://github.com/mikgroup/sigpy/blob/8c25c53a15b99643be7adcdc351f7ba55fcea649/sigpy/mri/linop.py#L160

I'm not so familiar with the shapes that are required here, whether it is important that `grd_shape` is a certain shape, so I haven't changed anything there. @frankong could you advise on whether I should try to make similar changes here or just leave them the way they are?