### PR TITLE
Add min time gradient code for arbitrary trajectories. 

### DIFF
--- a/docs/mri_rf.rst
+++ b/docs/mri_rf.rst
@@ -108,7 +108,7 @@ Trajectory and Gradient Design Functions
     sigpy.mri.rf.trajgrad.stack_of
     sigpy.mri.rf.traj_complex_to_array
     sigpy.mri.rf.traj_array_to_complex
-	sigpy.mri.rf.min_time_gradient
+    sigpy.mri.rf.min_time_gradient
 
 RF Utility
 --------------------------

--- a/docs/mri_rf.rst
+++ b/docs/mri_rf.rst
@@ -108,6 +108,7 @@ Trajectory and Gradient Design Functions
     sigpy.mri.rf.trajgrad.stack_of
     sigpy.mri.rf.traj_complex_to_array
     sigpy.mri.rf.traj_array_to_complex
+	sigpy.mri.rf.min_time_gradient
 
 RF Utility
 --------------------------

--- a/sigpy/config.py
+++ b/sigpy/config.py
@@ -18,7 +18,7 @@ mpi4py_enabled = util.find_spec("mpi4py") is not None
 
 # This is to catch an import error when the cudnn in cupy (system) and pytorch
 # (built in) are in conflict.
-if util.find_spec("torch"):
+if util.find_spec("torch") is not None:
     try:
         import torch  # noqa
         pytorch_enabled = True

--- a/sigpy/config.py
+++ b/sigpy/config.py
@@ -14,8 +14,10 @@ else:
     cudnn_enabled = False
     nccl_enabled = False
 
-mpi4py_enabled = util.find_spec("mpi4py")
+mpi4py_enabled = util.find_spec("mpi4py") is not None
 
+# This is to catch an import error when the cudnn in cupy (system) and pytorch
+# (built in) are in conflict.
 if util.find_spec("torch"):
     try:
         import torch  # noqa

--- a/sigpy/config.py
+++ b/sigpy/config.py
@@ -14,6 +14,14 @@ else:
     cudnn_enabled = False
     nccl_enabled = False
 
-mpi4py_enabled = util.find_spec("mpi4py") is not None
+mpi4py_enabled = util.find_spec("mpi4py")
 
-pytorch_enabled = util.find_spec("torch") is not None
+if util.find_spec("torch"):
+    try:
+        import torch  # noqa
+        pytorch_enabled = True
+    except ImportError:
+        print('Warning : Pytorch installed but can import')
+        pytorch_enabled = False
+else:
+    pytorch_enabled = False

--- a/sigpy/mri/rf/trajgrad.py
+++ b/sigpy/mri/rf/trajgrad.py
@@ -3,6 +3,12 @@
 """
 
 import numpy as np
+from scipy import interpolate
+from scipy import integrate
+import numba as nb
+import math
+import matplotlib.pyplot as plt
+
 
 __all__ = ['trap_grad', 'spiral_varden', 'spiral_arch', 'epi', 'rosette',
            'stack_of', 'traj_array_to_complex', 'traj_complex_to_array']
@@ -590,3 +596,247 @@ def traj_array_to_complex(k):
     """
     kout = k[:, 0] + 1j * k[:, 1]
     return kout
+
+
+@nb.jit(nopython=True, cache=True)  # pragma: no cover
+def runge_kutta(ds: float, st: float, kvals: np.ndarray, smax=None,
+                gamma=4.257):
+    """Runge-Kutta 4 for curve constrained
+
+    Args:
+        ds (float): spacing in arc length space
+        st (float): output shape.
+        kvals (array): 3 points of curve.
+        smax (float): maximum slew
+        gamma (float): gyromagnetic ratio
+    Returns:
+        float or None: step size dsdt or None
+    """
+    temp = (gamma ** 2 * smax ** 2 - abs(kvals[0]) ** 2 * st ** 4)
+    if temp < 0.0:
+        return None
+    k1 = ds / st * math.sqrt(temp)
+
+    temp = \
+        (gamma ** 2 * smax ** 2 - abs(kvals[1]) ** 2 * (st + ds * k1 / 2) ** 4)
+    if temp < 0.0:
+        return None
+    k2 = ds / (st + ds * k1 / 2) * math.sqrt(temp)
+
+    temp = \
+        (gamma ** 2 * smax ** 2 - abs(kvals[1]) ** 2 * (st + ds * k2 / 2) ** 4)
+    if temp < 0.0:
+        return None
+    k3 = ds / (st + ds * k2 / 2) * math.sqrt(temp)
+
+    temp = \
+        (gamma ** 2 * smax ** 2 - abs(kvals[2]) ** 2 * (st + ds * k3) ** 4)
+    if temp < 0.0:
+        return None
+    k4 = ds / (st + ds * k3) * math.sqrt(temp)
+
+    return k1 / 6 + k2 / 3 + k3 / 3 + k4 / 6
+
+
+def min_time_gradient(c: np.ndarray, g0=0, gfin=0, gmax=4, smax=15,
+                      dt=4e-3, show=False, gamma=4.257):
+    r"""Given a k-space trajectory c(n), gradient and slew constraints. This
+    function will return a new parametrization that will meet these
+    constraint while getting from one point to the other in minimum time.
+        (c) Michael Lustig 2005
+        modified 2006 and 2007
+        Rewritten in Python in 2020 by Kevin Johnson
+
+    Args:
+        c (array): The Curve in k-space given in any parametrization [1/cm]
+                    a Nx3 real array.
+        g0 (float): Initial gradient amplitude (leave empty for g0 = 0)
+        gfin (float): Gradient value at the end of the trajectory. If not
+                        possible, the result would be the largest possible
+                        ampltude. (Leave empty if you don't care to get
+                         maximum gradient.)
+        gmax (float): Maximum gradient [G/cm] (3.9 default)
+        smax (float): Maximum slew [G/Cm/ms]  (14.5 default)
+        dt (float): Sampling time interval [ms] (4e-3 default)
+        show (bool): Show plots while optimizing (Warning: This will make the
+                    process considerably slower!)
+        gamma (float): Gyromagnetic ration
+
+    Returns:
+        Tuple containing:
+
+        - **c** (*array*): reparametrized curve, sampled at T[ms],
+        - **time** (*array*): sampled time,
+        - **g** (*array*): gradient waveform [G/cm],
+        - **s** (*array*): slew rate [G/cm/ms],
+        - **k** (*array*): exact k-space corresponding to gradient g (This
+                            function reparametrizes C, then takes a derivative.
+                             Numerical errors in the derivative can lead to
+                            deviation.
+
+    """
+
+    def sdotmax(cs: interpolate.CubicSpline, s: np.ndarray,
+                gmax, smax, gamma=4.257):
+        # [sdot, k, ] = sdotMax(PP, p_of_s, s, gmax, smax)
+        #
+        # Given a k-space curve C (in [1/cm] units), maximum gradient amplitude
+        # (in G/cm) and maximum slew-rate (in G/(cm*ms)).
+        # This function calculates the upper bound for the time parametrization
+        # sdot (which is a non scaled max gradient constaint) as a function
+        # of s.
+        #
+        #   cs      --  spline polynomial
+        #   p_of_s  --  parametrization vs arclength
+        #   s       --  arclength parametrization (0->1)
+        #   gmax    --  maximum gradient (G/cm)
+        #   smax    --  maximum slew rate (G/ cm*ms)
+        #
+        #   returns the maximum sdot (1st derivative of s) as a function of
+        #   arclength s
+        #   Also, returns curvature as a function of s and length of curve (L)
+        #
+        #  (c) Michael Lustig 2005
+        #  last modified 2006
+
+        # Absolute value of 2nd derivative in curve space using cubic splines
+        cs2 = cs.derivative(2)  # spline derivative
+        cs2_highres = cs2(s)  # evaluated along arc length
+        k = np.linalg.norm(cs2_highres, axis=1)  # magnitude
+
+        # calc I constraint curve (maximum gradient)
+        sdot1 = gamma * gmax * np.ones_like(s)
+
+        # calc II constraint curve (curve curvature dependent)
+        sdot2 = np.sqrt(gamma * smax / (k + np.finfo(float).eps))
+
+        # calc total constraint
+        sdot = np.minimum(sdot1, sdot2)
+
+        return sdot, k
+
+    # Curve in arbitrary paramater space, cubic spline
+    num_p = c.shape[0]
+    p = np.linspace(0, 1, num_p, endpoint=True)
+    cp = interpolate.CubicSpline(p, c, axis=0)
+
+    # Integrate absolute value to find length and s(arc) vs p(paramater)
+    cp1_spline = cp.derivative()
+    p_highres = np.linspace(0, 1, num_p * 10)
+    cp1_highres = cp1_spline(p_highres)
+    ds_p = np.linalg.norm(cp1_highres, axis=1)
+
+    # s vs p to enable conversion
+    s_of_p = integrate.cumtrapz(ds_p, p_highres, initial=0)
+    curve_length = s_of_p[-1]
+
+    print(f'Length of curve {curve_length}')
+
+    # decide ds and compute st for the first point
+    stt0 = (gamma * smax)  # always assumes first point is max slew
+    st0 = stt0 * dt / 8  # start at 1/8 the gradient for accuracy close to g=0
+    s0 = st0 * dt
+    ds = s0 / 4.0  # smaller step size for numerical accuracy
+    ns = int(curve_length / ds)
+
+    if g0 is None:
+        g0 = 0
+
+    # s is arc length at high resolution
+    s = np.linspace(0, curve_length, ns, endpoint=True)
+
+    # Cubic spline at s positions (s of p)
+    cp_highres = cp(p_highres)
+    cs = interpolate.CubicSpline(s_of_p, cp_highres, axis=0)
+
+    print('Compute geometry dependent constraints')
+
+    # compute constraints (forbidden line curve)
+    phi, k = sdotmax(cs, s, gmax, smax)
+
+    # extend for the Runge-Kutte method
+    k = np.pad(k, (0, 3), 'constant', constant_values=(0,))
+
+    # Get the start
+    sta = np.zeros_like(s)
+    sta[0] = min(g0 * gamma + st0, gamma * gmax)
+
+    print('Solve ODE forward')
+    # solve ODE forward
+    for n in range(1, s.shape[0]):
+        kpos = n
+        dstds = runge_kutta(ds, sta[n - 1], k[kpos:kpos + 4], smax)
+
+        if dstds is None:
+            sta[n] = phi[n]
+        else:
+            tmpst = sta[n - 1] + dstds
+            sta[n] = min(tmpst, phi[n])
+
+    if show:
+        plt.figure()
+        plt.plot(np.linspace(s[0], s[-1], len(phi)), phi)
+        plt.plot(s, sta)
+        plt.show()
+
+    stb = 0 * s
+    if gfin is None:
+        stb[-1] = sta[-1]
+    else:
+        stb[-1] = min(max(gfin * gamma, st0), gamma * gmax)
+
+    # solve ODE backwards
+    print('Solve ODE backwards')
+    for n in range(s.shape[0] - 2, 0, -1):
+
+        kpos_end = n  # to 0
+        kpos = kpos_end + 3
+        dstds = runge_kutta(ds, stb[n + 1], k[kpos:(kpos - 3):-1], smax)
+
+        if dstds is None:
+            stb[n] = phi[n - 1]
+        else:
+            tmpst = stb[n + 1] + dstds
+            stb[n] = min(tmpst, phi[n - 1])
+
+    # Fix last point which is indexed a bit off
+    n = 0
+    kpos_end = n
+    kpos = kpos_end + 3
+    dstds = runge_kutta(ds, stb[n + 1], k[kpos::-1], smax)
+    if dstds is None:
+        stb[n] = phi[n * 2 - 1]
+    else:
+        tmpst = stb[n + 1] + dstds
+        stb[n] = min(tmpst, phi[n - 1])
+
+    if show:
+        plt.figure()
+        plt.plot(np.linspace(s[0], s[-1], len(phi)), phi)
+        plt.plot(s, sta)
+        plt.plot(s, stb)
+        plt.show()
+
+    print('Final Interpolations')
+    # take the minimum of the curves
+    ds = s[1] - s[0]
+    st_of_s = np.minimum(sta, stb)
+
+    # compute time
+    t_of_s = integrate.cumtrapz(1. / st_of_s, initial=0) * ds
+
+    print(f't_of_s max {t_of_s[-1]}')
+    t = np.arange(0, t_of_s[-1] + np.finfo(float).eps, dt)
+
+    t_of_s = interpolate.CubicSpline(t_of_s, s)
+    s_of_t = t_of_s(t)
+    c = np.squeeze(cs(s_of_t))
+
+    g = np.diff(c, axis=0, append=np.zeros((1, 3))) / gamma / dt
+    g[-1, :] = g[-2, :] + g[-2, :] - g[-3, :]
+
+    k = integrate.cumtrapz(g, t, initial=0, axis=0) * gamma
+
+    s = np.diff(g, axis=0) / dt
+
+    return g, k, s, t

--- a/tests/mri/rf/test_trajgrad.py
+++ b/tests/mri/rf/test_trajgrad.py
@@ -19,6 +19,6 @@ class TestTrajGrad(unittest.TestCase):
 
         (g, k, s, t) = rf.min_time_gradient(k, 0.0, 0.0,
                                             gmax=4, smax=15, dt=4e-3,
-                                            show=False, gamma=4.257)
+                                            gamma=4.257)
 
         npt.assert_almost_equal(np.max(t), 0.916, decimal=4)

--- a/tests/mri/rf/test_trajgrad.py
+++ b/tests/mri/rf/test_trajgrad.py
@@ -1,0 +1,24 @@
+import unittest
+import numpy as np
+import numpy.testing as npt
+import sigpy.mri.rf as rf
+import math
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+class TestTrajGrad(unittest.TestCase):
+
+    def test_min_gradient(self):
+        t = np.linspace(0, 1, 1000)
+        kx = np.sin(2.0 * math.pi * t)
+        ky = np.cos(2.0 * math.pi * t)
+        kz = t
+        k = np.stack((kx, ky, kz), axis=-1)
+
+        (g, k, s, t) = rf.min_time_gradient(k, 0.0, 0.0,
+                                            gmax=4, smax=15, dt=4e-3,
+                                            show=False, gamma=4.257)
+
+        npt.assert_almost_equal(np.max(t), 0.916, decimal=4)

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -21,8 +21,9 @@ if config.pytorch_enabled:
                         xp = device.xp
                         array = xp.array([1, 2, 3], dtype=dtype)
                         tensor = pytorch.to_pytorch(array)
+                        array[0] = 0
                         torch.testing.assert_allclose(
-                            tensor, torch.tensor([1, 2, 3],
+                            tensor, torch.tensor([0, 2, 3],
                                                  dtype=tensor.dtype,
                                                  device=tensor.device))
 
@@ -33,8 +34,9 @@ if config.pytorch_enabled:
                         xp = device.xp
                         array = xp.array([1 + 1j, 2 + 2j, 3 + 3j], dtype=dtype)
                         tensor = pytorch.to_pytorch(array)
+                        array[0] = 0
                         torch.testing.assert_allclose(
-                            tensor, torch.tensor([[1, 1], [2, 2], [3, 3]],
+                            tensor, torch.tensor([[0, 0], [2, 2], [3, 3]],
                                                  dtype=tensor.dtype,
                                                  device=tensor.device))
 

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -1,7 +1,6 @@
 import unittest
 import numpy as np
 import numpy.testing as npt
-
 from sigpy import backend, config, linop, pytorch
 
 if config.pytorch_enabled:

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -1,12 +1,11 @@
 import unittest
 import numpy as np
 import numpy.testing as npt
-from sigpy import backend, config, linop, pytorch
 
+from sigpy import backend, config, linop, pytorch
 
 if config.pytorch_enabled:
     import torch
-
     if __name__ == '__main__':
         unittest.main()
 
@@ -23,8 +22,10 @@ if config.pytorch_enabled:
                         xp = device.xp
                         array = xp.array([1, 2, 3], dtype=dtype)
                         tensor = pytorch.to_pytorch(array)
-                        tensor[0] = 0
-                        xp.testing.assert_allclose(array, [0, 2, 3])
+                        torch.testing.assert_allclose(
+                            tensor, torch.tensor([1, 2, 3],
+                                                 dtype=tensor.dtype,
+                                                 device=tensor.device))
 
         def test_to_pytorch_complex(self):
             for dtype in [np.complex64, np.complex128]:
@@ -33,8 +34,10 @@ if config.pytorch_enabled:
                         xp = device.xp
                         array = xp.array([1 + 1j, 2 + 2j, 3 + 3j], dtype=dtype)
                         tensor = pytorch.to_pytorch(array)
-                        tensor[0, 0] = 0
-                        xp.testing.assert_allclose(array, [1j, 2 + 2j, 3 + 3j])
+                        torch.testing.assert_allclose(
+                            tensor, torch.tensor([[1, 1], [2, 2], [3, 3]],
+                                                 dtype=tensor.dtype,
+                                                 device=tensor.device))
 
         def test_from_pytorch(self):
             for dtype in [torch.float32, torch.float64]:


### PR DESCRIPTION
This is to add a python version of Miki's arc length based gradient calculations. There are also some minor changes to pytorch import and testing. Since the prebuilt pytorch versions are linked to their own cudnn this can be in conflict with the cudnn from condaforge (e.g. 8.05 (broken on condaforge) vs 8.1). If you import pytorch first this is fixed for now.  