### PR TITLE
update config.py to treat cupy as an optional dependency

### DIFF
--- a/sigpy/config.py
+++ b/sigpy/config.py
@@ -4,9 +4,20 @@
 This module contains flags to turn on and off optional modules.
 
 """
+import warnings
 from importlib import util
 
 cupy_enabled = util.find_spec("cupy") is not None
+if cupy_enabled:
+    try:
+        import cupy  # noqa
+    except ImportError as e:
+        warnings.warn(
+            f"Importing cupy failed. "
+            f"For more details, see the error stack below:\n{e}"
+        )
+        cupy_enabled = False
+
 if cupy_enabled:  # pragma: no cover
     cudnn_enabled = util.find_spec("cupy.cuda.cudnn") is not None
     nccl_enabled = util.find_spec("cupy.cuda.nccl") is not None


### PR DESCRIPTION
This PR makes cupy more of an optional dependency in sigpy. When cupy import fails, sigpy raises a warning, instead of an error. This allows sigpy to continue operating without cupy being available.

### Testing
This scenario is difficult to simulate via unittests. However, it was verified in the case below:

Scenario:`machineA` has gpu, `machineB` does not have gpu. Both machines share a single NAS filesystem.
1. Conda environment created using machineA on shared NAS. This environment is also visible to machineB
2. `import sigpy` works on machineA - this is expected and was happening before.
3. `import sigpy` also works on machineB, even though gpu is not available on machineB

Resolves #77 