### PR TITLE
Fix SENSE linop to work with coil_batch_size > 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.8"
 
 install:
-  - pip install -r requirements.txt
+  - pip install --upgrade -r requirements.txt
   - pip install codecov flake8 sphinx sphinx_rtd_theme matplotlib
 
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numba
-numpy
+numpy<=1.20
 PyWavelets
 scipy
 tqdm

--- a/sigpy/mri/linop.py
+++ b/sigpy/mri/linop.py
@@ -45,9 +45,10 @@ def Sense(mps, coord=None, weights=None, tseg=None, ishape=None,
 
     if coil_batch_size < len(mps):
         num_coil_batches = (num_coils + coil_batch_size - 1) // coil_batch_size
-        A = sp.linop.Vstack([Sense(mps[c::num_coil_batches], coord=coord,
-                                   weights=weights, ishape=ishape)
-                             for c in range(num_coil_batches)], axis=0)
+        A = sp.linop.Vstack(
+            [Sense(mps[c*coil_batch_size:((c+1)*coil_batch_size)],
+                   coord=coord, weights=weights, ishape=ishape)
+             for c in range(num_coil_batches)], axis=0)
 
         if comm is not None:
             C = sp.linop.AllReduceAdjoint(ishape, comm, in_place=True)

--- a/tests/mri/test_app.py
+++ b/tests/mri/test_app.py
@@ -32,11 +32,13 @@ class TestApp(unittest.TestCase):
                        'GradientMethod',
                        'PrimalDualHybridGradient',
                        'ADMM']:
-            with self.subTest(solver=solver):
-                img_rec = app.SenseRecon(
-                    ksp, mps, lamda, solver=solver,
-                    show_pbar=False).run()
-                npt.assert_allclose(img, img_rec, atol=1e-2, rtol=1e-2)
+            for coil_batch_size in [None, 1, 2, 3]:
+                with self.subTest(solver=solver):
+                    img_rec = app.SenseRecon(
+                        ksp, mps, lamda, solver=solver,
+                        coil_batch_size=coil_batch_size,
+                        show_pbar=False).run()
+                    npt.assert_allclose(img, img_rec, atol=1e-2, rtol=1e-2)
 
     if sp.config.mpi4py_enabled:
         def test_shepp_logan_SenseRecon_with_comm(self):

--- a/tests/mri/test_linop.py
+++ b/tests/mri/test_linop.py
@@ -46,10 +46,11 @@ class TestLinop(unittest.TestCase):
         img = sp.randn(img_shape, dtype=np.complex)
         mps = sp.randn(mps_shape, dtype=np.complex)
 
-        A = linop.Sense(mps, coil_batch_size=1)
-        check_linop_adjoint(A, dtype=np.complex)
-        npt.assert_allclose(sp.fft(img * mps, axes=[-1, -2]),
-                            A * img)
+        for coil_batch_size in [None, 1, 2, 3]:
+            A = linop.Sense(mps, coil_batch_size=coil_batch_size)
+            check_linop_adjoint(A, dtype=np.complex)
+            npt.assert_allclose(sp.fft(img * mps, axes=[-1, -2]),
+                                A * img)
 
     def test_noncart_sense_model(self):
         img_shape = [16, 16]
@@ -106,10 +107,11 @@ class TestLinop(unittest.TestCase):
         coord = np.stack([np.ravel(y - 8), np.ravel(x - 8)], axis=1)
         coord = coord.astype(np.float)
 
-        A = linop.Sense(mps, coord=coord, coil_batch_size=1)
-        check_linop_adjoint(A, dtype=np.complex)
-        npt.assert_allclose(sp.fft(img * mps, axes=[-1, -2]).ravel(),
-                            (A * img).ravel(), atol=0.1, rtol=0.1)
+        for coil_batch_size in [None, 1, 2, 3]:
+            A = linop.Sense(mps, coord=coord, coil_batch_size=coil_batch_size)
+            check_linop_adjoint(A, dtype=np.complex)
+            npt.assert_allclose(sp.fft(img * mps, axes=[-1, -2]).ravel(),
+                                (A * img).ravel(), atol=0.1, rtol=0.1)
 
     if sp.config.mpi4py_enabled:
         def test_sense_model_with_comm(self):


### PR DESCRIPTION
Fix: When using coil_batch_size, SENSE linop stacked coil sensitivity maps interleavedly, which does not work properly for coil_batch_size > 1. Now, SENSE linop stacks them successively.
Test: Modified function in test_app (test_shepp_logan_SenseRecon) and modified two in test_linop (test_sense_model_batch and test_noncart_sense_model_batch) for coil_batch_size >= 1.