### PR TITLE
Remove deprecated type specifiers

### DIFF
--- a/sigpy/alg.py
+++ b/sigpy/alg.py
@@ -588,7 +588,7 @@ class SDMM(Alg):
         M = len(self.L)
         with self.device:
             xp = self.device.xp
-            self.x = xp.zeros(self.A.ishape, dtype=np.complex).flatten()
+            self.x = xp.zeros(self.A.ishape, dtype=complex).flatten()
             self.x = xp.expand_dims(self.x, axis=1)
             self.z, self.u = [], []
 

--- a/sigpy/app.py
+++ b/sigpy/app.py
@@ -115,7 +115,7 @@ class MaxEig(App):
 
     """
 
-    def __init__(self, A, dtype=np.float, device=backend.cpu_device,
+    def __init__(self, A, dtype=float, device=backend.cpu_device,
                  max_iter=30, show_pbar=True, leave_pbar=True):
         self.x = util.randn(A.ishape, dtype=dtype, device=device)
         alg = PowerMethod(A, self.x, max_iter=max_iter)

--- a/sigpy/mri/samp.py
+++ b/sigpy/mri/samp.py
@@ -87,7 +87,7 @@ def poisson(img_shape, accel, calib=(0, 0), dtype=np.complex,
     return mask
 
 
-def radial(coord_shape, img_shape, golden=True, dtype=np.float):
+def radial(coord_shape, img_shape, golden=True, dtype=float):
     """Generate radial trajectory.
 
     Args:

--- a/sigpy/mri/samp.py
+++ b/sigpy/mri/samp.py
@@ -8,7 +8,7 @@ import numba as nb
 __all__ = ['poisson', 'radial', 'spiral']
 
 
-def poisson(img_shape, accel, calib=(0, 0), dtype=np.complex,
+def poisson(img_shape, accel, calib=(0, 0), dtype=complex,
             crop_corner=True, return_density=False, seed=0,
             max_attempts=30, tol=0.1):
     """Generate variable-density Poisson-disc sampling pattern.

--- a/sigpy/mri/sim.py
+++ b/sigpy/mri/sim.py
@@ -7,7 +7,7 @@ import numpy as np
 __all__ = ['birdcage_maps']
 
 
-def birdcage_maps(shape, r=1.5, nzz=8, dtype=np.complex):
+def birdcage_maps(shape, r=1.5, nzz=8, dtype=complex):
     """Simulates birdcage coil sensitivies.
 
     Args:

--- a/sigpy/mri/util.py
+++ b/sigpy/mri/util.py
@@ -66,7 +66,7 @@ def tseg_off_res_b_ct(b0, bins, lseg, dt, T):
     """
 
     # create time vector
-    t = np.linspace(0, T, np.int(T/dt))
+    t = np.linspace(0, T, int(T/dt))
     hist_wt, bin_edges = np.histogram(np.imag(2j * np.pi * np.concatenate(b0)),
                                       bins)
 

--- a/sigpy/sim.py
+++ b/sigpy/sim.py
@@ -7,7 +7,7 @@ import numpy as np
 __all__ = ['shepp_logan']
 
 
-def shepp_logan(shape, dtype=np.complex):
+def shepp_logan(shape, dtype=complex):
     """Generates a Shepp Logan phantom with a given shape and dtype.
 
     Args:

--- a/sigpy/util.py
+++ b/sigpy/util.py
@@ -233,7 +233,7 @@ def upsample(input, oshape, factors, shift=None):
     return output
 
 
-def dirac(shape, dtype=np.float, device=backend.cpu_device):
+def dirac(shape, dtype=float, device=backend.cpu_device):
     """Create Dirac delta.
 
     Args:
@@ -252,7 +252,7 @@ def dirac(shape, dtype=np.float, device=backend.cpu_device):
         return resize(xp.ones([1], dtype=dtype), shape)
 
 
-def randn(shape, scale=1, dtype=np.float, device=backend.cpu_device):
+def randn(shape, scale=1, dtype=float, device=backend.cpu_device):
     """Create random Gaussian array.
 
     Args:
@@ -280,7 +280,7 @@ def randn(shape, scale=1, dtype=np.float, device=backend.cpu_device):
             return xp.random.normal(size=shape, scale=scale).astype(dtype)
 
 
-def triang(shape, dtype=np.float, device=backend.cpu_device):
+def triang(shape, dtype=float, device=backend.cpu_device):
     """Create multi-dimensional triangular window.
 
     Args:
@@ -305,7 +305,7 @@ def triang(shape, dtype=np.float, device=backend.cpu_device):
     return window
 
 
-def hanning(shape, dtype=np.float, device=backend.cpu_device):
+def hanning(shape, dtype=float, device=backend.cpu_device):
     """Create multi-dimensional hanning window.
 
     Args:

--- a/tests/learn/test_app.py
+++ b/tests/learn/test_app.py
@@ -12,8 +12,8 @@ class TestApp(unittest.TestCase):
     def test_ConvSparseDecom(self):
         lamda = 1e-9
         L = np.array([[1, 1],
-                      [1, -1]], dtype=np.float) / 2**0.5
-        y = np.array([[1, 1]], dtype=np.float) / 2**0.5
+                      [1, -1]], dtype=float) / 2**0.5
+        y = np.array([[1, 1]], dtype=float) / 2**0.5
 
         R = app.ConvSparseDecom(y, L, lamda=lamda).run()
 
@@ -22,8 +22,8 @@ class TestApp(unittest.TestCase):
     def test_ConvSparseCoefficients(self):
         lamda = 1e-10
         L = np.array([[1, 1],
-                      [1, -1]], dtype=np.float) / 2**0.5
-        y = np.array([[1, 1]], dtype=np.float) / 2**0.5
+                      [1, -1]], dtype=float) / 2**0.5
+        y = np.array([[1, 1]], dtype=float) / 2**0.5
 
         R_j = app.ConvSparseCoefficients(y, L, lamda=lamda)
 
@@ -36,7 +36,7 @@ class TestApp(unittest.TestCase):
         num_atoms = 1
         filt_width = 2
         batch_size = 1
-        y = np.array([[1, 1]], dtype=np.float) / 2**0.5
+        y = np.array([[1, 1]], dtype=float) / 2**0.5
         lamda = 1e-10
         alpha = 1
 

--- a/tests/mri/test_app.py
+++ b/tests/mri/test_app.py
@@ -87,7 +87,7 @@ class TestApp(unittest.TestCase):
         img_shape = [6, 6]
         mps_shape = [4, 6, 6]
 
-        img = np.ones(img_shape, dtype=np.complex)
+        img = np.ones(img_shape, dtype=complex)
         mps = sim.birdcage_maps(mps_shape)
         ksp = sp.fft(mps * img, axes=[-2, -1])
 

--- a/tests/mri/test_linop.py
+++ b/tests/mri/test_linop.py
@@ -9,7 +9,7 @@ if __name__ == '__main__':
     unittest.main()
 
 
-def check_linop_adjoint(A, dtype=np.float, device=sp.cpu_device):
+def check_linop_adjoint(A, dtype=float, device=sp.cpu_device):
 
     device = sp.Device(device)
     x = sp.randn(A.ishape, dtype=dtype, device=device)
@@ -61,7 +61,7 @@ class TestLinop(unittest.TestCase):
 
         y, x = np.mgrid[:16, :16]
         coord = np.stack([np.ravel(y - 8), np.ravel(x - 8)], axis=1)
-        coord = coord.astype(np.float)
+        coord = coord.astype(float)
 
         A = linop.Sense(mps, coord=coord)
         check_linop_adjoint(A, dtype=np.complex)
@@ -77,7 +77,7 @@ class TestLinop(unittest.TestCase):
 
         y, x = np.mgrid[:16, :16]
         coord = np.stack([np.ravel(y - 8), np.ravel(x - 8)], axis=1)
-        coord = coord.astype(np.float)
+        coord = coord.astype(float)
 
         d = np.sqrt(x * x + y * y)
         sigma, mu, a = 2, 0.25, 400
@@ -105,7 +105,7 @@ class TestLinop(unittest.TestCase):
 
         y, x = np.mgrid[:16, :16]
         coord = np.stack([np.ravel(y - 8), np.ravel(x - 8)], axis=1)
-        coord = coord.astype(np.float)
+        coord = coord.astype(float)
 
         for coil_batch_size in [None, 1, 2, 3]:
             A = linop.Sense(mps, coord=coord, coil_batch_size=coil_batch_size)

--- a/tests/mri/test_linop.py
+++ b/tests/mri/test_linop.py
@@ -29,12 +29,12 @@ class TestLinop(unittest.TestCase):
         img_shape = [16, 16]
         mps_shape = [8, 16, 16]
 
-        img = sp.randn(img_shape, dtype=np.complex)
-        mps = sp.randn(mps_shape, dtype=np.complex)
+        img = sp.randn(img_shape, dtype=complex)
+        mps = sp.randn(mps_shape, dtype=complex)
 
         A = linop.Sense(mps)
 
-        check_linop_adjoint(A, dtype=np.complex)
+        check_linop_adjoint(A, dtype=complex)
 
         npt.assert_allclose(sp.fft(img * mps, axes=[-1, -2]),
                             A * img)
@@ -43,12 +43,12 @@ class TestLinop(unittest.TestCase):
         img_shape = [16, 16]
         mps_shape = [8, 16, 16]
 
-        img = sp.randn(img_shape, dtype=np.complex)
-        mps = sp.randn(mps_shape, dtype=np.complex)
+        img = sp.randn(img_shape, dtype=complex)
+        mps = sp.randn(mps_shape, dtype=complex)
 
         for coil_batch_size in [None, 1, 2, 3]:
             A = linop.Sense(mps, coil_batch_size=coil_batch_size)
-            check_linop_adjoint(A, dtype=np.complex)
+            check_linop_adjoint(A, dtype=complex)
             npt.assert_allclose(sp.fft(img * mps, axes=[-1, -2]),
                                 A * img)
 
@@ -56,15 +56,15 @@ class TestLinop(unittest.TestCase):
         img_shape = [16, 16]
         mps_shape = [8, 16, 16]
 
-        img = sp.randn(img_shape, dtype=np.complex)
-        mps = sp.randn(mps_shape, dtype=np.complex)
+        img = sp.randn(img_shape, dtype=complex)
+        mps = sp.randn(mps_shape, dtype=complex)
 
         y, x = np.mgrid[:16, :16]
         coord = np.stack([np.ravel(y - 8), np.ravel(x - 8)], axis=1)
         coord = coord.astype(float)
 
         A = linop.Sense(mps, coord=coord)
-        check_linop_adjoint(A, dtype=np.complex)
+        check_linop_adjoint(A, dtype=complex)
         npt.assert_allclose(sp.fft(img * mps, axes=[-1, -2]).ravel(),
                             (A * img).ravel(), atol=0.1, rtol=0.1)
 
@@ -72,8 +72,8 @@ class TestLinop(unittest.TestCase):
         img_shape = [16, 16]
         mps_shape = [8, 16, 16]
 
-        img = sp.randn(img_shape, dtype=np.complex)
-        mps = sp.randn(mps_shape, dtype=np.complex)
+        img = sp.randn(img_shape, dtype=complex)
+        mps = sp.randn(mps_shape, dtype=complex)
 
         y, x = np.mgrid[:16, :16]
         coord = np.stack([np.ravel(y - 8), np.ravel(x - 8)], axis=1)
@@ -93,15 +93,15 @@ class TestLinop(unittest.TestCase):
 
         A = linop.Sense(mps, coord=coord, tseg=tseg)
 
-        check_linop_adjoint(A, dtype=np.complex)
+        check_linop_adjoint(A, dtype=complex)
         npt.assert_allclose(B1 * F * S * Ct1 * img, A * img)
 
     def test_noncart_sense_model_batch(self):
         img_shape = [16, 16]
         mps_shape = [8, 16, 16]
 
-        img = sp.randn(img_shape, dtype=np.complex)
-        mps = sp.randn(mps_shape, dtype=np.complex)
+        img = sp.randn(img_shape, dtype=complex)
+        mps = sp.randn(mps_shape, dtype=complex)
 
         y, x = np.mgrid[:16, :16]
         coord = np.stack([np.ravel(y - 8), np.ravel(x - 8)], axis=1)
@@ -109,7 +109,7 @@ class TestLinop(unittest.TestCase):
 
         for coil_batch_size in [None, 1, 2, 3]:
             A = linop.Sense(mps, coord=coord, coil_batch_size=coil_batch_size)
-            check_linop_adjoint(A, dtype=np.complex)
+            check_linop_adjoint(A, dtype=complex)
             npt.assert_allclose(sp.fft(img * mps, axes=[-1, -2]).ravel(),
                                 (A * img).ravel(), atol=0.1, rtol=0.1)
 
@@ -119,8 +119,8 @@ class TestLinop(unittest.TestCase):
             mps_shape = [8, 16, 16]
             comm = sp.Communicator()
 
-            img = sp.randn(img_shape, dtype=np.complex)
-            mps = sp.randn(mps_shape, dtype=np.complex)
+            img = sp.randn(img_shape, dtype=complex)
+            mps = sp.randn(mps_shape, dtype=complex)
             comm.allreduce(img)
             comm.allreduce(mps)
             ksp = sp.fft(img * mps, axes=[-1, -2])

--- a/tests/mri/test_precond.py
+++ b/tests/mri/test_precond.py
@@ -54,7 +54,7 @@ class TestPrecond(unittest.TestCase):
         shape = [nc, n]
         mps = sp.randn(shape, dtype=np.complex)
         mps /= np.linalg.norm(mps, axis=0, keepdims=True)
-        coord = sp.randn([n, 1], dtype=np.float)
+        coord = sp.randn([n, 1], dtype=float)
 
         A = linop.Sense(mps, coord=coord)
 
@@ -158,7 +158,7 @@ class TestPrecond(unittest.TestCase):
         shape = [nc, n]
         mps = np.ones(shape, dtype=np.complex)
         mps /= np.linalg.norm(mps, axis=0, keepdims=True)
-        coord = sp.randn([n, 1], dtype=np.float)
+        coord = sp.randn([n, 1], dtype=float)
 
         A = linop.Sense(mps, coord=coord)
         F = sp.linop.FFT([n])

--- a/tests/mri/test_precond.py
+++ b/tests/mri/test_precond.py
@@ -15,16 +15,16 @@ class TestPrecond(unittest.TestCase):
         nc = 4
         n = 10
         shape = (nc, n)
-        mps = sp.randn(shape, dtype=np.complex)
+        mps = sp.randn(shape, dtype=complex)
         mps /= np.linalg.norm(mps, axis=0, keepdims=True)
         weights = sp.randn([n]) >= 0
 
         A = sp.linop.Multiply(shape, weights**0.5) * linop.Sense(mps)
 
-        AAH = np.zeros((nc, n, nc, n), np.complex)
+        AAH = np.zeros((nc, n, nc, n), complex)
         for d in range(nc):
             for j in range(n):
-                x = np.zeros((nc, n), np.complex)
+                x = np.zeros((nc, n), complex)
                 x[d, j] = 1.0
                 AAHx = A(A.H(x))
 
@@ -32,7 +32,7 @@ class TestPrecond(unittest.TestCase):
                     for i in range(n):
                         AAH[c, i, d, j] = AAHx[c, i]
 
-        p_expected = np.ones((nc, n), np.complex)
+        p_expected = np.ones((nc, n), complex)
         for c in range(nc):
             for i in range(n):
                 if weights[i]:
@@ -52,23 +52,23 @@ class TestPrecond(unittest.TestCase):
         n = 10
         nc = 3
         shape = [nc, n]
-        mps = sp.randn(shape, dtype=np.complex)
+        mps = sp.randn(shape, dtype=complex)
         mps /= np.linalg.norm(mps, axis=0, keepdims=True)
         coord = sp.randn([n, 1], dtype=float)
 
         A = linop.Sense(mps, coord=coord)
 
-        AAH = np.zeros((nc, n, nc, n), np.complex)
+        AAH = np.zeros((nc, n, nc, n), complex)
         for d in range(nc):
             for j in range(n):
-                x = np.zeros(shape, np.complex)
+                x = np.zeros(shape, complex)
                 x[d, j] = 1.0
                 AAHx = A(A.H(x))
                 for c in range(nc):
                     for i in range(n):
                         AAH[c, i, d, j] = AAHx[c, i]
 
-        p_expected = np.zeros([nc, n], np.complex)
+        p_expected = np.zeros([nc, n], complex)
         for c in range(nc):
             for i in range(n):
                 p_expected_inv_ic = 0
@@ -85,29 +85,29 @@ class TestPrecond(unittest.TestCase):
     def test_kspace_precond_simple_cart(self):
         # Check identity
         mps_shape = [1, 1]
-        mps = np.ones(mps_shape, dtype=np.complex)
+        mps = np.ones(mps_shape, dtype=complex)
         p = precond.kspace_precond(mps)
         npt.assert_allclose(p, np.ones(mps_shape),
                             atol=1e-6, rtol=1e-6)
 
         # Check scaling
         mps_shape = [1, 3]
-        mps = np.ones(mps_shape, dtype=np.complex)
+        mps = np.ones(mps_shape, dtype=complex)
         p = precond.kspace_precond(mps)
         npt.assert_allclose(p, np.ones(mps_shape),
                             atol=1e-6, rtol=1e-6)
 
         # Check 2d
         mps_shape = [1, 3, 3]
-        mps = np.ones(mps_shape, dtype=np.complex)
+        mps = np.ones(mps_shape, dtype=complex)
         p = precond.kspace_precond(mps)
         npt.assert_allclose(p, np.ones(mps_shape),
                             atol=1e-6, rtol=1e-6)
 
         # Check weights
         mps_shape = [1, 3]
-        mps = np.ones(mps_shape, dtype=np.complex)
-        weights = np.array([1, 0, 1], dtype=np.complex)
+        mps = np.ones(mps_shape, dtype=complex)
+        weights = np.array([1, 0, 1], dtype=complex)
         p = precond.kspace_precond(mps, weights=weights)
         npt.assert_allclose(p, [[1, 1, 1]],
                             atol=1e-6, rtol=1e-6)
@@ -116,7 +116,7 @@ class TestPrecond(unittest.TestCase):
         # Check identity
         mps_shape = [1, 1]
 
-        mps = np.ones(mps_shape, dtype=np.complex)
+        mps = np.ones(mps_shape, dtype=complex)
         coord = np.array([[0.0]])
         p = precond.kspace_precond(mps, coord=coord)
         npt.assert_allclose(p, [[1.0]],
@@ -124,7 +124,7 @@ class TestPrecond(unittest.TestCase):
 
         mps_shape = [1, 3]
 
-        mps = np.ones(mps_shape, dtype=np.complex)
+        mps = np.ones(mps_shape, dtype=complex)
         coord = np.array([[0.0], [-1], [1]])
         p = precond.kspace_precond(mps, coord=coord)
         npt.assert_allclose(p, [[1.0, 1.0, 1.0]],
@@ -134,17 +134,17 @@ class TestPrecond(unittest.TestCase):
         nc = 4
         n = 10
         shape = (nc, n)
-        mps = sp.randn(shape, dtype=np.complex)
+        mps = sp.randn(shape, dtype=complex)
         mps /= np.linalg.norm(mps, axis=0, keepdims=True)
         weights = sp.randn([n]) >= 0
 
         A = sp.linop.Multiply(shape, weights**0.5) * linop.Sense(mps)
         F = sp.linop.FFT([n])
 
-        p_expected = np.zeros(n, np.complex)
+        p_expected = np.zeros(n, complex)
         for i in range(n):
             if weights[i]:
-                x = np.zeros(n, np.complex)
+                x = np.zeros(n, complex)
                 x[i] = 1.0
                 p_expected[i] = 1 / F(A.H(A(F.H(x))))[i]
 
@@ -156,16 +156,16 @@ class TestPrecond(unittest.TestCase):
         nc = 4
         n = 10
         shape = [nc, n]
-        mps = np.ones(shape, dtype=np.complex)
+        mps = np.ones(shape, dtype=complex)
         mps /= np.linalg.norm(mps, axis=0, keepdims=True)
         coord = sp.randn([n, 1], dtype=float)
 
         A = linop.Sense(mps, coord=coord)
         F = sp.linop.FFT([n])
 
-        p_expected = np.zeros(n, np.complex)
+        p_expected = np.zeros(n, complex)
         for i in range(n):
-            x = np.zeros(n, np.complex)
+            x = np.zeros(n, complex)
             x[i] = 1.0
             p_expected[i] = 1 / F(A.H(A(F.H(x))))[i]
 

--- a/tests/test_alg.py
+++ b/tests/test_alg.py
@@ -177,7 +177,7 @@ class TestAlg(unittest.TestCase):
         x_numpy = np.expand_dims(x_numpy, 1)
         A = np.csingle(A)
         A = linop.MatMul(y.shape, A)
-        x0 = np.zeros(A.ishape, dtype=np.complex)
+        x0 = np.zeros(A.ishape, dtype=complex)
 
         alg_method = alg.GerchbergSaxton(A, y, x0, max_iter=100, tol=10E-9,
                                          lamb=lamda)

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -10,11 +10,11 @@ if __name__ == '__main__':
 class TestFourier(unittest.TestCase):
 
     def test_fft(self):
-        input = np.array([0, 1, 0], dtype=np.complex)
+        input = np.array([0, 1, 0], dtype=complex)
         npt.assert_allclose(fourier.fft(input),
                             np.ones(3) / 3**0.5, atol=1e-5)
 
-        input = np.array([1, 1, 1], dtype=np.complex)
+        input = np.array([1, 1, 1], dtype=complex)
         npt.assert_allclose(fourier.fft(input),
                             [0, 3**0.5, 0], atol=1e-5)
 
@@ -24,7 +24,7 @@ class TestFourier(unittest.TestCase):
                                 np.fft.ifftshift(input), norm='ortho')),
                             atol=1e-5)
 
-        input = np.array([0, 1, 0], dtype=np.complex)
+        input = np.array([0, 1, 0], dtype=complex)
         npt.assert_allclose(fourier.fft(input, oshape=[5]),
                             np.ones(5) / 5**0.5, atol=1e-5)
 
@@ -37,11 +37,11 @@ class TestFourier(unittest.TestCase):
             assert output.dtype == dtype
 
     def test_ifft(self):
-        input = np.array([0, 1, 0], dtype=np.complex)
+        input = np.array([0, 1, 0], dtype=complex)
         npt.assert_allclose(fourier.ifft(input),
                             np.ones(3) / 3 ** 0.5, atol=1e-5)
 
-        input = np.array([1, 1, 1], dtype=np.complex)
+        input = np.array([1, 1, 1], dtype=complex)
         npt.assert_allclose(fourier.ifft(input),
                             [0, 3**0.5, 0], atol=1e-5)
 
@@ -51,28 +51,28 @@ class TestFourier(unittest.TestCase):
                                 np.fft.ifftshift(input), norm='ortho')),
                             atol=1e-5)
 
-        input = np.array([0, 1, 0], dtype=np.complex)
+        input = np.array([0, 1, 0], dtype=complex)
         npt.assert_allclose(fourier.ifft(input, oshape=[5]),
                             np.ones(5) / 5**0.5, atol=1e-5)
 
     def test_nufft(self):
 
         # Check deltas
-        input = np.array([0, 1, 0], np.complex)  # delta
+        input = np.array([0, 1, 0], complex)  # delta
         coord = np.array([[-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft(input, coord),
                             np.array([1.0, 1.0, 1.0]) / (3**0.5),
                             atol=0.01, rtol=0.01)
 
-        input = np.array([0, 0, 1, 0], np.complex)  # delta
+        input = np.array([0, 0, 1, 0], complex)  # delta
         coord = np.array([[-2], [-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft(input, coord),
                             np.array([1.0, 1.0, 1.0, 1.0]) / (4**0.5),
                             atol=0.01, rtol=0.01)
 
-        input = np.array([0, 0, 1, 0, 0], np.complex)  # delta
+        input = np.array([0, 0, 1, 0, 0], complex)  # delta
         coord = np.array([[-2], [-1], [0], [1], [2]], float)
 
         npt.assert_allclose(fourier.nufft(input, coord),
@@ -80,7 +80,7 @@ class TestFourier(unittest.TestCase):
                             atol=0.01, rtol=0.01)
 
         # Check shifted delta
-        input = np.array([0, 0, 1], np.complex)  # shifted delta
+        input = np.array([0, 0, 1], complex)  # shifted delta
         coord = np.array([[-1], [0], [1]], float)
 
         w = np.exp(-1j * 2.0 * np.pi / 3.0)
@@ -88,7 +88,7 @@ class TestFourier(unittest.TestCase):
                             np.array([w.conjugate(), 1.0, w]) / (3**0.5),
                             atol=0.01, rtol=0.01)
 
-        input = np.array([0, 0, 0, 1], np.complex)  # delta
+        input = np.array([0, 0, 0, 1], complex)  # delta
         coord = np.array([[-2], [-1], [0], [1]], float)
 
         w = np.exp(-1j * 2.0 * np.pi / 4.0)
@@ -101,7 +101,7 @@ class TestFourier(unittest.TestCase):
     def test_nufft_nd(self):
 
         for ndim in range(3):
-            input = np.array([[0], [1], [0]], np.complex)
+            input = np.array([[0], [1], [0]], complex)
             coord = np.array([[-1, 0],
                               [0, 0],
                               [1, 0]], float)
@@ -114,7 +114,7 @@ class TestFourier(unittest.TestCase):
 
         # Check deltas
         oshape = [3]
-        input = np.array([1.0, 1.0, 1.0], dtype=np.complex) / 3**0.5
+        input = np.array([1.0, 1.0, 1.0], dtype=complex) / 3**0.5
         coord = np.array([[-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
@@ -122,19 +122,19 @@ class TestFourier(unittest.TestCase):
                             atol=0.01, rtol=0.01)
 
         oshape = [4]
-        input = np.array([1.0, 1.0, 1.0, 1.0], dtype=np.complex) / 4**0.5
+        input = np.array([1.0, 1.0, 1.0, 1.0], dtype=complex) / 4**0.5
         coord = np.array([[-2], [-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
-                            np.array([0, 0, 1, 0], np.complex),
+                            np.array([0, 0, 1, 0], complex),
                             atol=0.01, rtol=0.01)
 
         oshape = [5]
-        input = np.ones(5, dtype=np.complex) / 5**0.5
+        input = np.ones(5, dtype=complex) / 5**0.5
         coord = np.array([[-2], [-1], [0], [1], [2]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
-                            np.array([0, 0, 1, 0, 0], np.complex),
+                            np.array([0, 0, 1, 0, 0], complex),
                             atol=0.01, rtol=0.01)
 
         # Check shifted delta
@@ -144,7 +144,7 @@ class TestFourier(unittest.TestCase):
         coord = np.array([[-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
-                            np.array([0, 0, 1], np.complex),
+                            np.array([0, 0, 1], complex),
                             atol=0.01, rtol=0.01)
 
         oshape = [4]
@@ -153,27 +153,27 @@ class TestFourier(unittest.TestCase):
         coord = np.array([[-2], [-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
-                            np.array([0, 0, 0, 1], np.complex),
+                            np.array([0, 0, 0, 1], complex),
                             atol=0.01, rtol=0.01)
 
     def test_nufft_adjoint_nd(self):
 
         oshape = [3, 1]
 
-        input = np.array([1.0, 1.0, 1.0], dtype=np.complex) / 3**0.5
+        input = np.array([1.0, 1.0, 1.0], dtype=complex) / 3**0.5
         coord = np.array([[-1, 0],
                           [0, 0],
                           [1, 0]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
-                            np.array([[0], [1], [0]], np.complex),
+                            np.array([[0], [1], [0]], complex),
                             atol=0.01, rtol=0.01)
 
     def test_nufft_normal(self):
 
         # Check delta
         oshape = [3]
-        input = np.array([0.0, 1.0, 0.0], dtype=np.complex)
+        input = np.array([0.0, 1.0, 0.0], dtype=complex)
         coord = np.array([[-1], [0], [1]], float)
 
         npt.assert_allclose(
@@ -183,7 +183,7 @@ class TestFourier(unittest.TestCase):
 
         # Check delta scale
         oshape = [3]
-        input = np.array([0.0, 1.0, 0.0], dtype=np.complex)
+        input = np.array([0.0, 1.0, 0.0], dtype=complex)
         coord = np.array([[-1], [-0.5], [0], [0.5], [1]], float)
 
         npt.assert_allclose(
@@ -210,7 +210,7 @@ class TestFourier(unittest.TestCase):
                       [w1**-2, w1**-1, 1, w1, w1**2]]) / n**0.5
 
         for i in range(n):
-            input = np.zeros(n, np.complex)
+            input = np.zeros(n, complex)
             input[i] = 1
             npt.assert_allclose(A[:, i], fourier.nufft(
                 input, coord), atol=0.01, rtol=0.01)
@@ -225,7 +225,7 @@ class TestFourier(unittest.TestCase):
                       [w1**-3, w1**-2, w1**-1, 1, w1, w1**2]]) / n**0.5
 
         for i in range(n):
-            input = np.zeros(n, np.complex)
+            input = np.zeros(n, complex)
             input[i] = 1
             npt.assert_allclose(A[:, i], fourier.nufft(
                 input, coord), atol=0.1, rtol=0.1)

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -59,21 +59,21 @@ class TestFourier(unittest.TestCase):
 
         # Check deltas
         input = np.array([0, 1, 0], np.complex)  # delta
-        coord = np.array([[-1], [0], [1]], np.float)
+        coord = np.array([[-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft(input, coord),
                             np.array([1.0, 1.0, 1.0]) / (3**0.5),
                             atol=0.01, rtol=0.01)
 
         input = np.array([0, 0, 1, 0], np.complex)  # delta
-        coord = np.array([[-2], [-1], [0], [1]], np.float)
+        coord = np.array([[-2], [-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft(input, coord),
                             np.array([1.0, 1.0, 1.0, 1.0]) / (4**0.5),
                             atol=0.01, rtol=0.01)
 
         input = np.array([0, 0, 1, 0, 0], np.complex)  # delta
-        coord = np.array([[-2], [-1], [0], [1], [2]], np.float)
+        coord = np.array([[-2], [-1], [0], [1], [2]], float)
 
         npt.assert_allclose(fourier.nufft(input, coord),
                             np.ones(5) / (5**0.5),
@@ -81,7 +81,7 @@ class TestFourier(unittest.TestCase):
 
         # Check shifted delta
         input = np.array([0, 0, 1], np.complex)  # shifted delta
-        coord = np.array([[-1], [0], [1]], np.float)
+        coord = np.array([[-1], [0], [1]], float)
 
         w = np.exp(-1j * 2.0 * np.pi / 3.0)
         npt.assert_allclose(fourier.nufft(input, coord),
@@ -89,7 +89,7 @@ class TestFourier(unittest.TestCase):
                             atol=0.01, rtol=0.01)
 
         input = np.array([0, 0, 0, 1], np.complex)  # delta
-        coord = np.array([[-2], [-1], [0], [1]], np.float)
+        coord = np.array([[-2], [-1], [0], [1]], float)
 
         w = np.exp(-1j * 2.0 * np.pi / 4.0)
         npt.assert_allclose(
@@ -104,7 +104,7 @@ class TestFourier(unittest.TestCase):
             input = np.array([[0], [1], [0]], np.complex)
             coord = np.array([[-1, 0],
                               [0, 0],
-                              [1, 0]], np.float)
+                              [1, 0]], float)
 
             npt.assert_allclose(fourier.nufft(input, coord),
                                 np.array([1.0, 1.0, 1.0]) / 3**0.5,
@@ -115,7 +115,7 @@ class TestFourier(unittest.TestCase):
         # Check deltas
         oshape = [3]
         input = np.array([1.0, 1.0, 1.0], dtype=np.complex) / 3**0.5
-        coord = np.array([[-1], [0], [1]], np.float)
+        coord = np.array([[-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
                             np.array([0, 1, 0]),
@@ -123,7 +123,7 @@ class TestFourier(unittest.TestCase):
 
         oshape = [4]
         input = np.array([1.0, 1.0, 1.0, 1.0], dtype=np.complex) / 4**0.5
-        coord = np.array([[-2], [-1], [0], [1]], np.float)
+        coord = np.array([[-2], [-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
                             np.array([0, 0, 1, 0], np.complex),
@@ -131,7 +131,7 @@ class TestFourier(unittest.TestCase):
 
         oshape = [5]
         input = np.ones(5, dtype=np.complex) / 5**0.5
-        coord = np.array([[-2], [-1], [0], [1], [2]], np.float)
+        coord = np.array([[-2], [-1], [0], [1], [2]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
                             np.array([0, 0, 1, 0, 0], np.complex),
@@ -141,7 +141,7 @@ class TestFourier(unittest.TestCase):
         oshape = [3]
         w = np.exp(-1j * 2.0 * np.pi / 3.0)
         input = np.array([w.conjugate(), 1.0, w]) / 3**0.5
-        coord = np.array([[-1], [0], [1]], np.float)
+        coord = np.array([[-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
                             np.array([0, 0, 1], np.complex),
@@ -150,7 +150,7 @@ class TestFourier(unittest.TestCase):
         oshape = [4]
         w = np.exp(-1j * 2.0 * np.pi / 4.0)
         input = np.array([w.conjugate()**2, w.conjugate(), 1.0, w]) / 4**0.5
-        coord = np.array([[-2], [-1], [0], [1]], np.float)
+        coord = np.array([[-2], [-1], [0], [1]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
                             np.array([0, 0, 0, 1], np.complex),
@@ -163,7 +163,7 @@ class TestFourier(unittest.TestCase):
         input = np.array([1.0, 1.0, 1.0], dtype=np.complex) / 3**0.5
         coord = np.array([[-1, 0],
                           [0, 0],
-                          [1, 0]], np.float)
+                          [1, 0]], float)
 
         npt.assert_allclose(fourier.nufft_adjoint(input, coord, oshape),
                             np.array([[0], [1], [0]], np.complex),
@@ -174,7 +174,7 @@ class TestFourier(unittest.TestCase):
         # Check delta
         oshape = [3]
         input = np.array([0.0, 1.0, 0.0], dtype=np.complex)
-        coord = np.array([[-1], [0], [1]], np.float)
+        coord = np.array([[-1], [0], [1]], float)
 
         npt.assert_allclose(
             fourier.nufft_adjoint(fourier.nufft(
@@ -184,7 +184,7 @@ class TestFourier(unittest.TestCase):
         # Check delta scale
         oshape = [3]
         input = np.array([0.0, 1.0, 0.0], dtype=np.complex)
-        coord = np.array([[-1], [-0.5], [0], [0.5], [1]], np.float)
+        coord = np.array([[-1], [-0.5], [0], [0.5], [1]], float)
 
         npt.assert_allclose(
             fourier.nufft_adjoint(

--- a/tests/test_linop.py
+++ b/tests/test_linop.py
@@ -16,7 +16,7 @@ if config.cupy_enabled:
 class TestLinop(unittest.TestCase):
 
     def check_linop_unitary(self, A,
-                            device=backend.cpu_device, dtype=np.float):
+                            device=backend.cpu_device, dtype=float):
         device = backend.Device(device)
         x = util.randn(A.ishape, dtype=dtype, device=device)
         xp = device.xp
@@ -25,7 +25,7 @@ class TestLinop(unittest.TestCase):
                                        atol=1e-5, rtol=1e-5)
 
     def check_linop_linear(self, A,
-                           device=backend.cpu_device, dtype=np.float):
+                           device=backend.cpu_device, dtype=float):
         device = backend.Device(device)
         a = util.randn([1], dtype=dtype, device=device)
         x = util.randn(A.ishape, dtype=dtype, device=device)
@@ -38,7 +38,7 @@ class TestLinop(unittest.TestCase):
                                        atol=1e-5, rtol=1e-5)
 
     def check_linop_adjoint(self, A,
-                            device=backend.cpu_device, dtype=np.float):
+                            device=backend.cpu_device, dtype=float):
         device = backend.Device(device)
         x = util.randn(A.ishape, dtype=dtype, device=device)
         y = util.randn(A.oshape, dtype=dtype, device=device)
@@ -53,7 +53,7 @@ class TestLinop(unittest.TestCase):
             rhs = xp.vdot(x, A.H * y)
             xp.testing.assert_allclose(lhs, rhs, rtol=1e-3)
 
-    def check_linop_normal(self, A, device=backend.cpu_device, dtype=np.float):
+    def check_linop_normal(self, A, device=backend.cpu_device, dtype=float):
         device = backend.Device(device)
         x = util.randn(A.ishape, dtype=dtype, device=device)
 

--- a/tests/test_linop.py
+++ b/tests/test_linop.py
@@ -241,8 +241,8 @@ class TestLinop(unittest.TestCase):
         self.check_linop_linear(A)
         self.check_linop_pickleable(A)
 
-        x = np.array([1.0, 2.0], np.complex)
-        y = np.array([1.1, 2.2], np.complex)
+        x = np.array([1.0, 2.0], complex)
+        y = np.array([1.1, 2.2], complex)
         npt.assert_allclose(A * x, y)
 
         # Test simple
@@ -255,8 +255,8 @@ class TestLinop(unittest.TestCase):
         self.check_linop_linear(A)
         self.check_linop_pickleable(A)
 
-        x = np.array([1.0, 2.0], np.complex)
-        y = np.array([1.0, 4.0], np.complex)
+        x = np.array([1.0, 2.0], complex)
+        y = np.array([1.0, 4.0], complex)
         npt.assert_allclose(A * x, y)
 
         # Test broadcasting
@@ -270,9 +270,9 @@ class TestLinop(unittest.TestCase):
         self.check_linop_linear(A)
         self.check_linop_pickleable(A)
 
-        x = np.array([1.0, 2.0], np.complex)
+        x = np.array([1.0, 2.0], complex)
         y = np.array([[1.0, 4.0],
-                      [3.0, 8.0]], np.complex)
+                      [3.0, 8.0]], complex)
         npt.assert_allclose(A * x, y)
 
     def test_Resize(self):
@@ -451,7 +451,7 @@ class TestLinop(unittest.TestCase):
         self.check_linop_linear(A)
         self.check_linop_pickleable(A)
 
-        x = np.array([1, 2, 3, 4], np.complex)
+        x = np.array([1, 2, 3, 4], complex)
 
         npt.assert_allclose(A(x), [[1, 2],
                                    [3, 4]])

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -77,7 +77,7 @@ if config.pytorch_enabled:
 
         def test_to_pytorch_function(self):
             A = linop.Resize([5], [3])
-            x = np.array([1, 2, 3], np.float)
+            x = np.array([1, 2, 3], float)
             y = np.ones([5])
 
             with self.subTest('forward'):
@@ -105,11 +105,11 @@ if config.pytorch_enabled:
                     output_iscomplex=True).apply
                 x_torch = pytorch.to_pytorch(x)
                 npt.assert_allclose(f(x_torch).detach().numpy().ravel(),
-                                    A(x).view(np.float))
+                                    A(x).view(float))
 
             with self.subTest('adjoint'):
                 y_torch = pytorch.to_pytorch(y)
                 loss = (f(x_torch) - y_torch).pow(2).sum() / 2
                 loss.backward()
                 npt.assert_allclose(x_torch.grad.detach().numpy().ravel(),
-                                    A.H(A(x) - y).view(np.float))
+                                    A.H(A(x) - y).view(float))

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -95,8 +95,8 @@ if config.pytorch_enabled:
 
         def test_to_pytorch_function_complex(self):
             A = linop.FFT([3])
-            x = np.array([1 + 1j, 2 + 2j, 3 + 3j], np.complex)
-            y = np.ones([3], np.complex)
+            x = np.array([1 + 1j, 2 + 2j, 3 + 3j], complex)
+            y = np.ones([3], complex)
 
             with self.subTest('forward'):
                 f = pytorch.to_pytorch_function(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -120,9 +120,9 @@ class TestUtil(unittest.TestCase):
                              [0, 1, 2]])
 
     def test_monte_carlo_sure(self):
-        x = np.ones([100000], dtype=np.float)
+        x = np.ones([100000], dtype=float)
         sigma = 0.1
-        noise = 0.1 * util.randn([100000], dtype=np.float)
+        noise = 0.1 * util.randn([100000], dtype=float)
         y = x + noise
 
         def f(y):


### PR DESCRIPTION
This changes all instances of 

np.complex -> complex
np.float -> float
np.bool -> bool
np.int -> int

as they are depcreated since numpy 1.20.

Closes #123.