### PR TITLE
Fix incompatibility with scipy 1.14.0 and numpy 2.0

### DIFF
--- a/sigpy/alg.py
+++ b/sigpy/alg.py
@@ -3,6 +3,7 @@
 and implements commonly used methods, such as gradient methods,
 Newton's method, and the augmented Lagrangian method.
 """
+
 import numpy as np
 
 import sigpy as sp
@@ -88,7 +89,7 @@ class PowerMethod(Alg):
     def __init__(self, A, x, norm_func=None, max_iter=30):
         self.A = A
         self.x = x
-        self.max_eig = np.infty
+        self.max_eig = np.inf
         self.norm_func = norm_func
         super().__init__(max_iter)
 
@@ -180,7 +181,7 @@ class GradientMethod(Alg):
                 self.z = self.x.copy()
                 self.t = 1
 
-        self.resid = np.infty
+        self.resid = np.inf
         super().__init__(max_iter)
 
     def _update(self):
@@ -371,7 +372,7 @@ class PrimalDualHybridGradient(Alg):
             with self.u_device:
                 self.sigma_min = xp.amin(xp.abs(sigma)).item()
 
-        self.resid = np.infty
+        self.resid = np.inf
 
         super().__init__(max_iter)
 
@@ -490,7 +491,7 @@ class AugmentedLagrangianMethod(Alg):
             xp = device.xp
             with device:
                 util.axpy(self.u, self.mu, self.g(self.x))
-                backend.copyto(self.u, xp.clip(self.u, 0, np.infty))
+                backend.copyto(self.u, xp.clip(self.u, 0, np.inf))
 
         if self.h is not None:
             util.axpy(self.v, self.mu, self.h(self.x))
@@ -802,10 +803,10 @@ class NewtonsMethod(Alg):
         self.gradf = gradf
         self.inv_hessf = inv_hessf
         self.x = x
-        self.lamda = np.infty
+        self.lamda = np.inf
         self.beta = beta
         self.f = f
-        self.residual = np.infty
+        self.residual = np.inf
         self.tol = tol
 
         super().__init__(max_iter)
@@ -864,7 +865,7 @@ class GerchbergSaxton(Alg):
         self.tol = tol
         self.max_tol = max_tol
         self.lamb = lamb
-        self.residual = np.infty
+        self.residual = np.inf
 
     def _update(self):
         device = backend.get_device(self.y)

--- a/sigpy/mri/rf/slr.py
+++ b/sigpy/mri/rf/slr.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """MRI RF excitation pulse design functions,
-    including SLR and small tip spatial design
+including SLR and small tip spatial design
 """
 
 import numpy as np
@@ -135,7 +135,7 @@ def dzls(n=64, tb=4, d1=0.01, d2=0.01):
     m = [1, 1, 0, 0]
     w = [1, d1 / d2]
 
-    h = signal.firls(n + 1, f, m, w)
+    h = signal.firls(n + 1, f, m, weight=w)
     # shift the filter half a sample to make it symmetric, like in MATLAB
     c = np.exp(
         1j
@@ -160,7 +160,7 @@ def dzmp(n=64, tb=4, d1=0.01, d2=0.01):
     m = [1, 0]
     w = [1, 2 * d1 / (0.5 * d2 * d2)]
 
-    hl = signal.remez(n2, f, m, w)
+    hl = signal.remez(n2, f, m, weight=w)
 
     h = fmp(hl)
 
@@ -188,7 +188,7 @@ def dzlp(n=64, tb=4, d1=0.01, d2=0.01):
     m = [1, 0]
     w = [1, d1 / d2]
 
-    h = signal.remez(n, f, m, w)
+    h = signal.remez(n, f, m, weight=w)
 
     return h
 
@@ -253,8 +253,8 @@ def dz_gslider_b(
             m_sub = [1, 1, 0, 0, 0, 0]
             w = [1, 1, d1 / d2]
 
-            b_notch = signal.firls(n + 1, f, m_notch, w)  # the notched filter
-            b_sub = signal.firls(n + 1, f, m_sub, w)  # the subslice filter
+            b_notch = signal.firls(n + 1, f, m_notch, weight=w)  # the notched filter
+            b_sub = signal.firls(n + 1, f, m_sub, weight=w)  # the subslice filter
             # add them with the subslice phase
             b = np.add(b_notch, np.multiply(np.exp(1j * phi), b_sub))
             # shift the filter half a sample to make it symmetric,
@@ -344,7 +344,7 @@ def dz_gslider_b(
             )
         )
 
-        b_notch = signal.firls(n + 1, f, m_notch, w)  # the notched filter
+        b_notch = signal.firls(n + 1, f, m_notch, weight=w)  # the notched filter
         b_notch = sp.ifft(
             np.multiply(sp.fft(b_notch, center=False), c), center=False
         )
@@ -352,7 +352,7 @@ def dz_gslider_b(
         # hilbert transform to suppress negative passband
         b_notch = signal.hilbert(b_notch)
 
-        b_sub = signal.firls(n + 1, f, m_sub, w)  # the sub-band filter
+        b_sub = signal.firls(n + 1, f, m_sub, weight=w)  # the sub-band filter
         b_sub = sp.ifft(
             np.multiply(sp.fft(b_sub, center=False), c), center=False
         )
@@ -460,8 +460,8 @@ def dz_hadamard_b(n=128, g=5, gind=1, tb=4, d1=0.01, d2=0.01, shift=32):
                 [np.arange(0, n / 2 + 1, 1), np.arange(-n / 2, 0, 1)]
             )
         )
-        bp = signal.firls(n + 1, f, mp, w)  # the positive filter
-        bn = signal.firls(n + 1, f, mn, w)  # the negative filter
+        bp = signal.firls(n + 1, f, mp, weight=w)  # the positive filter
+        bn = signal.firls(n + 1, f, mn, weight=w)  # the negative filter
 
         # combine the filters and demodulate
         b = sp.ifft(
@@ -793,7 +793,7 @@ def dz_recursive_rf(
         win_len = (win_fact - 1) * n
         npad = n * z_pad_fact - win_fact * n
         # blackman window?
-        window = signal.blackman(int((win_fact - 1) * n))
+        window = signal.windows.blackman(int((win_fact - 1) * n))
         # split in half; stick N ones in the middle
         window = np.concatenate(
             (

--- a/sigpy/mri/rf/trajgrad.py
+++ b/sigpy/mri/rf/trajgrad.py
@@ -906,7 +906,7 @@ def min_time_gradient(
     ds_p = np.linalg.norm(cp1_highres, axis=1)
 
     # s vs p to enable conversion
-    s_of_p = integrate.cumtrapz(ds_p, p_highres, initial=0)
+    s_of_p = integrate.cumulative_trapezoid(ds_p, p_highres, initial=0)
     curve_length = s_of_p[-1]
 
     # decide ds and compute st for the first point
@@ -981,7 +981,7 @@ def min_time_gradient(
     st_of_s = np.minimum(sta, stb)
 
     # compute time
-    t_of_s = integrate.cumtrapz(1.0 / st_of_s, initial=0) * ds
+    t_of_s = integrate.cumulative_trapezoid(1.0 / st_of_s, initial=0) * ds
 
     t = np.arange(0, t_of_s[-1] + np.finfo(float).eps, dt)
 
@@ -992,7 +992,7 @@ def min_time_gradient(
     g = np.diff(c, axis=0, append=np.zeros((1, 3))) / gamma / dt
     g[-1, :] = g[-2, :] + g[-2, :] - g[-3, :]
 
-    k = integrate.cumtrapz(g, t, initial=0, axis=0) * gamma
+    k = integrate.cumulative_trapezoid(g, t, initial=0, axis=0) * gamma
 
     s = np.diff(g, axis=0) / dt
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -8,4 +8,4 @@ if __name__ == "__main__":
 
 class TestVersion(unittest.TestCase):
     def test_version(self):
-        assert version.__version__ == "0.1.25"
+        assert version.__version__ == "0.1.26"


### PR DESCRIPTION
As described in #142, several changes in the scipy and numpy packages lead to errors in sigpy. 

I tried to fix them so that all tests pass now, but I am not a sigpy user myself and can't guarantee that all changes in the function calls, especially the introduction of the kwarg "weight", are actually correct. Would be great if someone could confirm that the one character variable `w` is supposed to be a `weight` (although from the scipy changelog I am quite sure that this is the case 😁 )

The rest should be fine. 


closes #142